### PR TITLE
feat(create-granite-app): allow empty string for project name

### DIFF
--- a/.changeset/plain-socks-send.md
+++ b/.changeset/plain-socks-send.md
@@ -1,0 +1,5 @@
+---
+'create-granite-app': minor
+---
+
+Allow empty string for project name in `create-granite-app` to using default value.

--- a/.changeset/plain-socks-send.md
+++ b/.changeset/plain-socks-send.md
@@ -2,4 +2,4 @@
 'create-granite-app': minor
 ---
 
-Allow empty string for project name in `create-granite-app` to using default value.
+Allow empty string for project name in `create-granite-app` to use the default value.

--- a/packages/create-granite-app/src/index.ts
+++ b/packages/create-granite-app/src/index.ts
@@ -15,6 +15,10 @@ function assertValidAppName(input: string) {
   const appName = getAppName(input);
   const kebabCaseAppName = kebabCase(appName);
 
+  if (appName === '') {
+    return;
+  }
+
   if (kebabCaseAppName !== appName) {
     throw new Error(`Project name must be in kebab-case (e.g. ${kebabCaseAppName})`);
   }


### PR DESCRIPTION
Allow empty input for the project name or path prompt to use the default value.

Previously, an empty input would cause a validation error. This change enables users to skip entering a name/path and use the predefined default.
