### PR TITLE
docs: clarify Granite test app connection steps and add dev server check reminder

### DIFF
--- a/docs/guides/quick-start/create-your-app.md
+++ b/docs/guides/quick-start/create-your-app.md
@@ -162,7 +162,7 @@ If you haven't already, install the Granite test app on your simulator:
 1. **Open your iOS Simulator** (or Android Emulator)
 2. **Launch the Granite test app** from your simulator
 3. **Connect to your development server:**
-   - Ensure your `npm run dev` is still running in the terminal
+   - Ensure your `granite dev` is still running in the terminal
    - **For Android users:** Run `adb reverse tcp:8081 tcp:8081` in a separate terminal to enable connection
    - In the Granite test app, tap **"Open Dev Server"**
    - The app will connect to your local development server and load your React Native screens

--- a/docs/guides/quick-start/create-your-app.md
+++ b/docs/guides/quick-start/create-your-app.md
@@ -159,9 +159,12 @@ If you haven't already, install the Granite test app on your simulator:
 
 ### 5.2 Run Your App
 
-1. Open your iOS Simulator (or Android Emulator)
-2. Launch the Granite test app
-3. The app will automatically connect to your development server
+1. **Open your iOS Simulator** (or Android Emulator)
+2. **Launch the Granite test app** from your simulator
+3. **Connect to your development server:**
+   - Ensure your `npm run dev` is still running in the terminal
+   - In the Granite test app, tap **"Open Dev Server"**
+   - The app will connect to your local development server and load your React Native screens
 
 You should see your app's home screen loading in the native app!
 

--- a/docs/guides/quick-start/create-your-app.md
+++ b/docs/guides/quick-start/create-your-app.md
@@ -163,6 +163,7 @@ If you haven't already, install the Granite test app on your simulator:
 2. **Launch the Granite test app** from your simulator
 3. **Connect to your development server:**
    - Ensure your `npm run dev` is still running in the terminal
+   - **For Android users:** Run `adb reverse tcp:8081 tcp:8081` in a separate terminal to enable connection
    - In the Granite test app, tap **"Open Dev Server"**
    - The app will connect to your local development server and load your React Native screens
 

--- a/docs/ko/guides/quick-start/create-your-app.md
+++ b/docs/ko/guides/quick-start/create-your-app.md
@@ -159,9 +159,12 @@ To open debugger press "j"
 
 ### 5.2 앱 실행
 
-1. iOS 시뮬레이터 또는 Android 에뮬레이터를 실행하세요
-2. Granite 테스트 앱을 실행하세요
-3. 앱이 자동으로 개발 서버에 연결돼요.
+1. **iOS 시뮬레이터** 또는 **Android 에뮬레이터**를 실행하세요
+2. 시뮬레이터에서 **Granite 테스트 앱**을 실행하세요
+3. **개발 서버에 연결하기:**
+   - 터미널에서 `npm run dev`가 계속 실행 중인지 확인하세요
+   - Granite 테스트 앱에서 **"Open Dev Server"**를 탭하세요
+   - 앱이 로컬 개발 서버에 연결되어 React Native 화면을 로드해요
 
 네이티브 앱에서 Granite 앱이 로딩되는 걸 볼 수 있어요.
 

--- a/docs/ko/guides/quick-start/create-your-app.md
+++ b/docs/ko/guides/quick-start/create-your-app.md
@@ -162,7 +162,7 @@ To open debugger press "j"
 1. **iOS 시뮬레이터** 또는 **Android 에뮬레이터**를 실행하세요
 2. 시뮬레이터에서 **Granite 테스트 앱**을 실행하세요
 3. **개발 서버에 연결하기:**
-   - 터미널에서 `npm run dev`가 계속 실행 중인지 확인하세요
+   - 터미널에서 `granite dev`가 계속 실행 중인지 확인하세요
    - **Android 사용자의 경우:** 별도 터미널에서 `adb reverse tcp:8081 tcp:8081` 명령어를 실행하여 연결을 활성화하세요
    - Granite 테스트 앱에서 **"Open Dev Server"**를 탭하세요
    - 앱이 로컬 개발 서버에 연결되어 React Native 화면을 로드해요

--- a/docs/ko/guides/quick-start/create-your-app.md
+++ b/docs/ko/guides/quick-start/create-your-app.md
@@ -163,6 +163,7 @@ To open debugger press "j"
 2. 시뮬레이터에서 **Granite 테스트 앱**을 실행하세요
 3. **개발 서버에 연결하기:**
    - 터미널에서 `npm run dev`가 계속 실행 중인지 확인하세요
+   - **Android 사용자의 경우:** 별도 터미널에서 `adb reverse tcp:8081 tcp:8081` 명령어를 실행하여 연결을 활성화하세요
    - Granite 테스트 앱에서 **"Open Dev Server"**를 탭하세요
    - 앱이 로컬 개발 서버에 연결되어 React Native 화면을 로드해요
 


### PR DESCRIPTION
## Problem
The current quick-start documentation contains misleading information about connecting to the development server:

- States "The app will automatically connect to your development server" ❌
- Users expect automatic connection but have to manually tap "Open Dev Server"
- Missing reminder to ensure dev server is running before attempting connection
- Causes confusion during the setup process for new users

## Solution
Updated the connection steps to be more accurate and user-friendly:

✅ Removed misleading "automatic connection" statement  
✅ Added explicit manual step to tap "Open Dev Server" in the UI  
✅ Added concise reminder to check dev server is running  
✅ Improved formatting with bold text and clear hierarchy  
✅ Made steps more semantic and actionable  

## Testing
- [x] Verified steps match actual Granite test app behavior (It works on iOS but has not yet been tested on Android)
- [x] Connection works when following updated instructions  

## Changes
- Updated English docs (`docs/guides/quick-start/create-your-app.md`)
- Updated Korean docs (`docs/ko/guides/quick-start/create-your-app.md`)  
- Enhanced step 3 in "5.2 Run Your App" section
- Added dev server status verification step

Improves the developer experience for new Granite users during initial setup.