### PR TITLE
fix: update docs replace useRouter with useNavigation in import

### DIFF
--- a/docs/guides/quick-start/create-your-app.md
+++ b/docs/guides/quick-start/create-your-app.md
@@ -219,12 +219,13 @@ const styles = StyleSheet.create({
 Update your `pages/index.tsx` to add navigation:
 
 ```tsx
+
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { useRouter } from '@granite/router';
+import { useNavigation } from '@granite-js/react-native'
 
 export default function HomeScreen() {
-  const router = useRouter();
+  const navigation = useNavigation();
 
   return (
     <View style={styles.container}>
@@ -232,7 +233,7 @@ export default function HomeScreen() {
       
       <TouchableOpacity 
         style={styles.button}
-        onPress={() => router.push('/profile')}
+        onPress={() => navigation.navigate('/profile')}
       >
         <Text style={styles.buttonText}>Go to Profile</Text>
       </TouchableOpacity>


### PR DESCRIPTION
## 이슈
기존 문서에서는 `@granite/router`의 `useRouter`를 사용하는 예시를 제공하고 있었으나,
`@granite-js/react-native`의 패키지를 사용해야 하므로 에러가 발생합니다.


![image](https://github.com/user-attachments/assets/ead677c4-8cc5-41d3-8470-9903f00fba9f)

## 해결
동일한 역할을 하는 `@granite/react-native의 useNavigation`으로 교체하여 문서를 수정했습니다.


![image](https://github.com/user-attachments/assets/70a4ae81-5b67-4ebd-9d50-40bdb1f8b64a)
