### PR TITLE
fix(plugin-sentry): read bundle content before extracting debug ID

### DIFF
--- a/.changeset/neat-dryers-guess.md
+++ b/.changeset/neat-dryers-guess.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/plugin-sentry': patch
+---
+
+read bundle content before extracting debug ID

--- a/packages/plugin-sentry/src/sentryPlugin.ts
+++ b/packages/plugin-sentry/src/sentryPlugin.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs/promises';
 import type { GranitePluginCore } from '@granite-js/plugin-core';
 import { noop } from 'es-toolkit';
 import { extractSentryDebugId } from './extractSentryDebugId';
@@ -31,7 +32,8 @@ export const sentryPlugin = ({ enabled = true, ...options }: SentryPluginOptions
 
         for (const file of files) {
           const { bundle, sourcemap } = file;
-          const debugId = await extractSentryDebugId(bundle);
+          const bundleContent = await fs.readFile(bundle, 'utf-8');
+          const debugId = await extractSentryDebugId(bundleContent);
 
           if (debugId == null) {
             console.error('Cannot find Sentry Debug ID');


### PR DESCRIPTION
# Description

Update to load content instead of a file path.

- No more "Cannot find Sentry Debug ID" logs
  - <img width="652" height="84" alt="image" src="https://github.com/user-attachments/assets/b373f1c8-f9b9-453e-8ebf-853412483a60" />
- `debugId` field included
  - <img width="553" height="160" alt="image" src="https://github.com/user-attachments/assets/bc07cdd0-9556-4af4-bdfd-5f316d5b0359" />

