### PR TITLE
chore: add `@typescript-eslint/types` to type-utils

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -23,6 +23,9 @@ packageExtensions:
   eslint-plugin-import@*:
     peerDependencies:
       typescript: '*'
+  '@typescript-eslint/type-utils@^8':
+    dependencies:
+      '@typescript-eslint/types': ^8
   jest-config@*:
     dependencies:
       ts-node: '*'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10139,6 +10139,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:^8":
+  version: 8.36.0
+  resolution: "@typescript-eslint/types@npm:8.36.0"
+  checksum: 10c0/cacb941a0caad6ab556c416051b97ec33b364b7c8e0703e2729ae43f12daf02b42eef12011705329107752e3f1685ca82cfffe181d637f85907293cb634bee31
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:8.32.1":
   version: 8.32.1
   resolution: "@typescript-eslint/typescript-estree@npm:8.32.1"


### PR DESCRIPTION
# Description

Explicitly add the dependency required by @typescript-eslint/type-utils to resolve the PnP issue.

<img width="1638" height="242" alt="image" src="https://github.com/user-attachments/assets/aa293f60-d4ed-48be-93cd-597d715c6b86" />

