### PR TITLE
feat: add additionalConfig reporter spec

### DIFF
--- a/packages/mpack/src/metro/getMetroConfig.ts
+++ b/packages/mpack/src/metro/getMetroConfig.ts
@@ -19,6 +19,9 @@ export interface GetMetroConfig {
 export interface AdditionalMetroConfig extends MetroConfig {
   transformSync?: (id: string, code: string) => string;
   babelConfig?: babel.TransformOptions;
+  reporter?: {
+    update: (event: any) => void;
+  };
 }
 
 const INTERNAL_CALLSITES_REGEX = new RegExp(
@@ -107,6 +110,7 @@ export async function getMetroConfig(
     server: {
       port: DEV_SERVER_DEFAULT_PORT,
     },
+    reporter: additionalConfig?.reporter,
     ...(process.env.METRO_RESET_CACHE !== 'false' ? { resetCache: true } : {}),
   });
 }

--- a/packages/mpack/src/metro/types.ts
+++ b/packages/mpack/src/metro/types.ts
@@ -88,4 +88,5 @@ export interface MetroConfig {
   readonly symbolicator?: any;
   readonly transformer?: any;
   readonly watcher?: any;
+  readonly reporter?: any;
 }

--- a/packages/mpack/src/operations/runServer.ts
+++ b/packages/mpack/src/operations/runServer.ts
@@ -79,7 +79,7 @@ export async function runServer({
   );
   const metroConfig = mergeConfig(baseConfig, {
     server: { port },
-    reporter
+    reporter,
   });
 
   const { middleware, websocketEndpoints, messageSocketEndpoint, eventsSocketEndpoint } = createDevServerMiddleware({

--- a/packages/mpack/src/operations/runServer.ts
+++ b/packages/mpack/src/operations/runServer.ts
@@ -53,6 +53,10 @@ export async function runServer({
       terminalReporter.update(event);
       ref.reportEvent?.(event);
 
+      if (baseConfig.reporter?.update) {
+        baseConfig.reporter.update(event);
+      }
+
       switch (event.type) {
         case 'initialize_started':
           printLogo();
@@ -75,7 +79,7 @@ export async function runServer({
   );
   const metroConfig = mergeConfig(baseConfig, {
     server: { port },
-    reporter,
+    reporter
   });
 
   const { middleware, websocketEndpoints, messageSocketEndpoint, eventsSocketEndpoint } = createDevServerMiddleware({


### PR DESCRIPTION
* additionalConfig.reporter를 plugin에서 받을 수 있도록 수정
참고: https://metrobundler.dev/docs/configuration/#reporter

기존에 event 타입이 any로 되어 있어서 우선 같이 맞춰뒀습니다.

문제 없을까요?