### PR TITLE
fix: `BuildUtils` and plugin types

### DIFF
--- a/.changeset/blue-turkeys-occur.md
+++ b/.changeset/blue-turkeys-occur.md
@@ -1,0 +1,7 @@
+---
+'@granite-js/plugin-core': patch
+'@granite-js/mpack': patch
+'@granite-js/cli': patch
+---
+
+fix `BuildUtils` errors and incorrect plugin types

--- a/infra/deployment-manager/package.json
+++ b/infra/deployment-manager/package.json
@@ -30,7 +30,7 @@
     "@vitest/coverage-v8": "^3.1.4",
     "aws-lambda": "^1.0.7",
     "aws-sdk-client-mock": "^4.1.0",
-    "es-toolkit": "^1.38.0",
+    "es-toolkit": "^1.39.8",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
     "valibot": "^1.1.0",

--- a/infra/pulumi-aws/package.json
+++ b/infra/pulumi-aws/package.json
@@ -42,7 +42,7 @@
     "@vitest/coverage-v8": "^3.1.4",
     "aws-lambda": "^1.0.7",
     "aws-sdk-client-mock": "^4.1.0",
-    "es-toolkit": "^1.38.0",
+    "es-toolkit": "^1.39.8",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
     "uuid": "^11.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "cosmiconfig-typescript-loader": "^5.1.0",
     "debug": "^4.3.7",
     "enquirer": "^2.4.1",
-    "es-toolkit": "^1.32.0",
+    "es-toolkit": "^1.39.8",
     "execa": "^5",
     "ora": "^5",
     "typanion": "^3.14.0",

--- a/packages/cli/src/config/defineConfig.ts
+++ b/packages/cli/src/config/defineConfig.ts
@@ -77,20 +77,16 @@ export const defineConfig = async (config: GraniteConfig): Promise<CompleteGrani
   const { configs, pluginHooks } = await resolvePlugins(parsed.plugins);
   const globalsScriptConfig = prepareGraniteGlobalsScript({ rootDir: cwd, appName, scheme });
   const mergedConfig = mergeConfig(parsedConfig, ...[globalsScriptConfig, ...configs].filter(isNotNil));
-  const { metro, devServer, ...buildConfig } = mergedConfig ?? {};
+  const { metro, devServer, ...build } = mergedConfig ?? {};
 
   return {
     cwd,
-    entryFile,
     appName,
-    scheme,
+    entryFile,
     outdir,
+    build,
     devServer,
     pluginHooks,
-    build: {
-      ...buildConfig,
-      entry: entryFile,
-    },
     metro: {
       ...metro,
       babelConfig: mergedConfig?.babel,

--- a/packages/create-granite-app/package.json
+++ b/packages/create-granite-app/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^22.10.2",
     "@types/yargs": "^17.0.33",
     "@vitest/coverage-v8": "^2.1.8",
-    "es-toolkit": "^1.30.1",
+    "es-toolkit": "^1.39.8",
     "execa": "^9.5.2",
     "kill-port": "^2.0.1",
     "tsup": "^8.5.0",

--- a/packages/mpack/package.json
+++ b/packages/mpack/package.json
@@ -110,7 +110,7 @@
     "denodeify": "^1.2.1",
     "enhanced-resolve": "^5.17.1",
     "error-stack-parser": "^2.0.6",
-    "es-toolkit": "^1.26.1",
+    "es-toolkit": "^1.39.8",
     "esbuild": "0.25.8",
     "events": "3.3.0",
     "fastify": "4.14.0",

--- a/packages/mpack/src/metro/build.ts
+++ b/packages/mpack/src/metro/build.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { BuildResult, createPluginHooksDriver, type CompleteGraniteConfig } from '@granite-js/plugin-core';
 import { Semaphore } from 'es-toolkit';
 import { getMetroConfig } from './getMetroConfig';
+import { getDefaultOutfileName } from '../utils/getDefaultOutfileName';
 import Metro from '../vendors/metro/src';
 
 interface CommonMetroBuildOptions {
@@ -61,20 +62,21 @@ export async function buildAll(
 
 async function buildImpl(
   config: CompleteGraniteConfig,
-  { platform, outfile = `bundle.${platform}.js`, minify = false, dev = true }: CommonMetroBuildOptions
+  { platform, outfile, minify = false, dev = true }: CommonMetroBuildOptions
 ) {
   const metroConfig = await getMetroConfig({ rootPath: config.cwd }, config.metro);
-  const out = path.join(config.outdir, outfile);
+  const outfileName = outfile == null ? getDefaultOutfileName(config.entryFile, platform) : outfile;
+  const outfilePath = path.join(config.outdir, outfileName);
 
   await Metro.runBuild(metroConfig, {
-    entry: config.entryFile,
-    out,
     platform,
+    entry: config.entryFile,
+    out: outfilePath,
     minify: minify,
     dev: dev,
   });
 
-  return buildResultShim(config, { outfile, platform, minify, dev });
+  return buildResultShim(config, { outfile: outfilePath, platform, minify, dev });
 }
 
 function buildResultShim(config: CompleteGraniteConfig, options: Required<CommonMetroBuildOptions>): BuildResult {

--- a/packages/mpack/src/metro/build.ts
+++ b/packages/mpack/src/metro/build.ts
@@ -42,15 +42,17 @@ export async function buildAll(
   const driver = createPluginHooksDriver(config);
   await driver.build.pre();
 
-  for (const options of optionsList) {
-    await semaphore.acquire();
-    try {
-      const buildResult = await buildImpl(config, options);
-      buildResults.push(buildResult);
-    } catch {
-      semaphore.release();
-    }
-  }
+  await Promise.all(
+    optionsList.map(async (options) => {
+      await semaphore.acquire();
+      try {
+        const buildResult = await buildImpl(config, options);
+        buildResults.push(buildResult);
+      } catch {
+        semaphore.release();
+      }
+    })
+  );
 
   await driver.build.post({ buildResults });
 

--- a/packages/mpack/src/operations/build.ts
+++ b/packages/mpack/src/operations/build.ts
@@ -10,6 +10,7 @@ import { Semaphore } from 'es-toolkit';
 import { Bundler } from '../bundler';
 import { Performance, printSummary } from '../performance';
 import type { BundlerConfig, PluginFactory } from '../types';
+import { getDefaultOutfileName } from '../utils/getDefaultOutfileName';
 import { writeBundle } from '../utils/writeBundle';
 
 type CommonBuildOptions = Omit<BundlerConfig, 'rootDir' | 'buildConfig'> & Pick<BuildConfig, 'platform' | 'outfile'>;
@@ -65,9 +66,10 @@ export async function buildAll(
 async function buildImpl(
   config: CompleteGraniteConfig,
   plugins: PluginFactory[],
-  { platform, outfile = `bundle.${platform}.js`, cache = true, dev = true, metafile = false }: CommonBuildOptions
+  { platform, outfile, cache = true, dev = true, metafile = false }: CommonBuildOptions
 ) {
-  const resolvedOutfile = path.join(config.outdir, outfile);
+  const outfileName = outfile == null ? getDefaultOutfileName(config.entryFile, platform) : outfile;
+  const outfilePath = path.resolve(config.outdir, outfileName);
   const bundler = new Bundler({
     rootDir: config.cwd,
     cache,
@@ -75,7 +77,8 @@ async function buildImpl(
     metafile,
     buildConfig: {
       platform,
-      outfile: resolvedOutfile,
+      entry: config.entryFile,
+      outfile: outfilePath,
       ...config.build,
     },
   });

--- a/packages/mpack/src/operations/experimental/serve.ts
+++ b/packages/mpack/src/operations/experimental/serve.ts
@@ -31,7 +31,7 @@ export async function EXPERIMENTAL__server({
 
   const rootDir = config.cwd;
   const server = new DevServer({
-    buildConfig: config.build,
+    buildConfig: { entry: config.entryFile, ...config.build },
     middlewares: config.devServer?.middlewares ?? [],
     host,
     port,

--- a/packages/mpack/src/testing/fixtures/build-with-config.js
+++ b/packages/mpack/src/testing/fixtures/build-with-config.js
@@ -5,9 +5,6 @@ const mpack = require('@granite-js/mpack');
   const rootDir = __dirname;
   const bundler = new mpack.Bundler({
     rootDir,
-    tag: 'test',
-    scheme: 'test',
-    appName: 'test',
     cache: false,
     dev: false,
     metafile: false,

--- a/packages/mpack/src/utils/__tests__/getDefaultOutfileName.spec.ts
+++ b/packages/mpack/src/utils/__tests__/getDefaultOutfileName.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { getDefaultOutfileName } from '../getDefaultOutfileName';
+
+describe('getDefaultOutfileName', () => {
+  it('should return the default outfile', () => {
+    expect(getDefaultOutfileName('src/index.tsx', 'android')).toBe('index.android.js');
+    expect(getDefaultOutfileName('src/index.tsx', 'ios')).toBe('index.ios.js');
+    expect(getDefaultOutfileName('src/entry.ts', 'android')).toBe('entry.android.js');
+    expect(getDefaultOutfileName('src/entry.ts', 'ios')).toBe('entry.ios.js');
+  });
+});

--- a/packages/mpack/src/utils/getDefaultOutfileName.ts
+++ b/packages/mpack/src/utils/getDefaultOutfileName.ts
@@ -1,0 +1,9 @@
+import path from 'path';
+
+export function getDefaultOutfileName(entryFile: string, platform: 'android' | 'ios') {
+  const basename = path.basename(entryFile);
+  const extname = path.extname(basename);
+  const name = basename.replace(extname, '');
+
+  return `${name}.${platform}.js`;
+}

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -26,18 +26,17 @@
     "dist"
   ],
   "devDependencies": {
-    "@swc/core": "1.5.24",
-    "@types/babel__core": "^7",
-    "@types/connect": "^3",
-    "connect": "^3.7.0",
-    "esbuild": "^0.25.8",
-    "fastify": "4.14.0",
     "tsdown": "^0.11.12",
     "typescript": "^5.6.3",
     "vitest": "^3.0.9"
   },
   "dependencies": {
+    "@swc/core": "1.5.24",
+    "@types/babel__core": "^7",
+    "@types/connect": "^3",
     "es-toolkit": "^1.39.8",
+    "esbuild": "^0.25.8",
+    "fastify": "4.14.0",
     "zod": "^4.0.10"
   },
   "sideEffects": false

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -37,7 +37,7 @@
     "vitest": "^3.0.9"
   },
   "dependencies": {
-    "es-toolkit": "^1.39.7",
+    "es-toolkit": "^1.39.8",
     "zod": "^4.0.10"
   },
   "sideEffects": false

--- a/packages/plugin-core/src/schema/pluginConfig.ts
+++ b/packages/plugin-core/src/schema/pluginConfig.ts
@@ -25,8 +25,12 @@ export const pluginConfigSchema = z.object({
 });
 
 export type GraniteConfig = z.input<typeof pluginConfigSchema>;
-export type CompleteGraniteConfig = Omit<z.output<typeof pluginConfigSchema>, 'build' | 'plugins'> & {
-  build: Omit<BuildConfig, 'platform' | 'outfile'>;
+export type ParsedGraniteConfig = z.output<typeof pluginConfigSchema>;
+export type CompleteGraniteConfig = Pick<
+  ParsedGraniteConfig,
+  'cwd' | 'appName' | 'entryFile' | 'outdir' | 'devServer' | 'metro'
+> & {
+  build: Omit<BuildConfig, 'platform' | 'entry' | 'outfile'>;
   pluginHooks: GranitePluginHooks;
 };
 

--- a/packages/plugin-hermes/package.json
+++ b/packages/plugin-hermes/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@granite-js/plugin-core": "workspace:*",
     "@granite-js/utils": "workspace:*",
-    "es-toolkit": "^1.38.0",
+    "es-toolkit": "^1.39.8",
     "execa": "^5",
     "source-map": "^0.8.0-beta.0"
   },

--- a/packages/plugin-micro-frontend/package.json
+++ b/packages/plugin-micro-frontend/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@granite-js/plugin-core": "workspace:*",
     "@granite-js/utils": "workspace:*",
-    "es-toolkit": "^1.38.0",
+    "es-toolkit": "^1.39.8",
     "picocolors": "^1.1.1"
   },
   "sideEffects": false

--- a/packages/plugin-router/package.json
+++ b/packages/plugin-router/package.json
@@ -39,7 +39,7 @@
     "@granite-js/plugin-core": "workspace:*",
     "@swc/core": "1.5.24",
     "chokidar": "4.0.1",
-    "es-toolkit": "^1.26.1"
+    "es-toolkit": "^1.39.8"
   },
   "sideEffects": false
 }

--- a/packages/plugin-sentry/package.json
+++ b/packages/plugin-sentry/package.json
@@ -36,7 +36,7 @@
     "@granite-js/plugin-core": "workspace:*",
     "@granite-js/utils": "workspace:*",
     "@sentry/cli": "^2.45.0",
-    "es-toolkit": "^1.38.0",
+    "es-toolkit": "^1.39.8",
     "execa": "^5"
   },
   "sideEffects": false

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -88,7 +88,7 @@
     "@granite-js/lottie": "workspace:*",
     "@granite-js/mpack": "workspace:*",
     "@granite-js/style-utils": "workspace:*",
-    "es-toolkit": "^1.34.1",
+    "es-toolkit": "^1.39.8",
     "react-native-url-polyfill": "1.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5121,7 +5121,7 @@ __metadata:
     cosmiconfig-typescript-loader: "npm:^5.1.0"
     debug: "npm:^4.3.7"
     enquirer: "npm:^2.4.1"
-    es-toolkit: "npm:^1.32.0"
+    es-toolkit: "npm:^1.39.8"
     esbuild: "npm:0.25.8"
     eslint: "npm:^9.7.0"
     execa: "npm:^5"
@@ -5145,7 +5145,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^3.1.4"
     aws-lambda: "npm:^1.0.7"
     aws-sdk-client-mock: "npm:^4.1.0"
-    es-toolkit: "npm:^1.38.0"
+    es-toolkit: "npm:^1.39.8"
     tsup: "npm:^8.5.0"
     typescript: "npm:^5.8.3"
     valibot: "npm:^1.1.0"
@@ -5312,7 +5312,7 @@ __metadata:
     denodeify: "npm:^1.2.1"
     enhanced-resolve: "npm:^5.17.1"
     error-stack-parser: "npm:^2.0.6"
-    es-toolkit: "npm:^1.26.1"
+    es-toolkit: "npm:^1.39.8"
     esbuild: "npm:0.25.8"
     eslint: "npm:9.7.0"
     events: "npm:3.3.0"
@@ -5425,7 +5425,7 @@ __metadata:
     "@types/babel__core": "npm:^7"
     "@types/connect": "npm:^3"
     connect: "npm:^3.7.0"
-    es-toolkit: "npm:^1.39.7"
+    es-toolkit: "npm:^1.39.8"
     esbuild: "npm:^0.25.8"
     fastify: "npm:4.14.0"
     tsdown: "npm:^0.11.12"
@@ -5459,7 +5459,7 @@ __metadata:
     "@granite-js/plugin-core": "workspace:*"
     "@granite-js/utils": "workspace:*"
     "@vitest/coverage-v8": "npm:^3.1.3"
-    es-toolkit: "npm:^1.38.0"
+    es-toolkit: "npm:^1.39.8"
     execa: "npm:^5"
     source-map: "npm:^0.8.0-beta.0"
     tsdown: "npm:^0.11.13"
@@ -5474,7 +5474,7 @@ __metadata:
   dependencies:
     "@granite-js/plugin-core": "workspace:*"
     "@granite-js/utils": "workspace:*"
-    es-toolkit: "npm:^1.38.0"
+    es-toolkit: "npm:^1.39.8"
     picocolors: "npm:^1.1.1"
     tsdown: "npm:^0.11.11"
     typescript: "npm:^5.8.3"
@@ -5491,7 +5491,7 @@ __metadata:
     "@types/node": "npm:^22.10.2"
     "@vitest/coverage-v8": "npm:^2.1.8"
     chokidar: "npm:4.0.1"
-    es-toolkit: "npm:^1.26.1"
+    es-toolkit: "npm:^1.39.8"
     tsdown: "npm:^0.11.12"
     typescript: "npm:5.8.3"
     vitest: "npm:^2.1.8"
@@ -5505,7 +5505,7 @@ __metadata:
     "@granite-js/plugin-core": "workspace:*"
     "@granite-js/utils": "workspace:*"
     "@sentry/cli": "npm:^2.45.0"
-    es-toolkit: "npm:^1.38.0"
+    es-toolkit: "npm:^1.39.8"
     execa: "npm:^5"
     tsdown: "npm:^0.11.11"
     typescript: "npm:^5.8.3"
@@ -5527,7 +5527,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^3.1.4"
     aws-lambda: "npm:^1.0.7"
     aws-sdk-client-mock: "npm:^4.1.0"
-    es-toolkit: "npm:^1.38.0"
+    es-toolkit: "npm:^1.39.8"
     oxc-transform: "npm:^0.71.0"
     tsup: "npm:^8.5.0"
     typescript: "npm:^5.8.3"
@@ -5561,7 +5561,7 @@ __metadata:
     "@types/react": "npm:18.3.3"
     "@types/react-dom": "npm:^18"
     "@vitest/coverage-v8": "npm:^2.1.8"
-    es-toolkit: "npm:^1.34.1"
+    es-toolkit: "npm:^1.39.8"
     esbuild: "npm:0.25.8"
     eslint: "npm:^9.7.0"
     jsdom: "npm:^25.0.1"
@@ -13115,7 +13115,7 @@ __metadata:
     "@types/node": "npm:^22.10.2"
     "@types/yargs": "npm:^17.0.33"
     "@vitest/coverage-v8": "npm:^2.1.8"
-    es-toolkit: "npm:^1.30.1"
+    es-toolkit: "npm:^1.39.8"
     execa: "npm:^9.5.2"
     kill-port: "npm:^2.0.1"
     tsup: "npm:^8.5.0"
@@ -14104,27 +14104,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-toolkit@npm:^1.26.1, es-toolkit@npm:^1.30.1, es-toolkit@npm:^1.32.0, es-toolkit@npm:^1.34.1, es-toolkit@npm:^1.38.0":
-  version: 1.38.0
-  resolution: "es-toolkit@npm:1.38.0"
+"es-toolkit@npm:^1.39.8":
+  version: 1.39.8
+  resolution: "es-toolkit@npm:1.39.8"
   dependenciesMeta:
     "@trivago/prettier-plugin-sort-imports@4.3.0":
       unplugged: true
     prettier-plugin-sort-re-exports@0.0.1:
       unplugged: true
-  checksum: 10c0/1bffc2d8dbe8db45969cf6674a674bdf9d40d803c923b01645b8a433f43f9304b1d369b6cde2a6ef3889a5aa71ddc741bf8e4103b4d4b48a366e04b4b3d30519
-  languageName: node
-  linkType: hard
-
-"es-toolkit@npm:^1.39.7":
-  version: 1.39.7
-  resolution: "es-toolkit@npm:1.39.7"
-  dependenciesMeta:
-    "@trivago/prettier-plugin-sort-imports@4.3.0":
-      unplugged: true
-    prettier-plugin-sort-re-exports@0.0.1:
-      unplugged: true
-  checksum: 10c0/dde082b76d22430bdef383bf60abb893ec4ebb50da9a900005e9b57481837b9118398897670cf33c5cdf473375345dc1e897820ede4ee58482407e9626b67ba3
+  checksum: 10c0/a13f50433959ae784d9eef467c7a3883f28bd40c651d6f62a11c93a0b7460b070a72a8c9c8d4423039d5d441a777cf2b9850113d9b3d04d1f65a79dccec04f31
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5424,7 +5424,6 @@ __metadata:
     "@swc/core": "npm:1.5.24"
     "@types/babel__core": "npm:^7"
     "@types/connect": "npm:^3"
-    connect: "npm:^3.7.0"
     es-toolkit: "npm:^1.39.8"
     esbuild: "npm:^0.25.8"
     fastify: "npm:4.14.0"


### PR DESCRIPTION
# Description

- Bump up `es-toolkit` version to use `Semaphore` in `BuildUtils`
- Move third-party types to `dependencies` field
- Remove duplicated config (entry)

closes #66 