### PR TITLE
fix: incorrect video property type

### DIFF
--- a/packages/react-native/src/video/Video.tsx
+++ b/packages/react-native/src/video/Video.tsx
@@ -62,7 +62,7 @@ type VideoProps = ComponentProps<typeof AnimatedRNVideo>;
  * }
  * ```
  */
-const Video = forwardRef<VideoRef, instance.VideoNativeProps>((props, ref) => {
+const VideoImpl = forwardRef<VideoRef, instance.VideoNativeProps>((props, ref) => {
   const [isFocused, setIsFocused] = useState(props.muted || props.paused);
   const visible = useVisibility();
 
@@ -93,12 +93,18 @@ const Video = forwardRef<VideoRef, instance.VideoNativeProps>((props, ref) => {
   );
 });
 
-Object.defineProperty(Video, 'isAvailable', {
-  value: instance.isAvailable,
+Object.defineProperty(VideoImpl, 'isAvailable', {
+  get: () => instance.isAvailable,
   enumerable: true,
   writable: false,
   configurable: false,
 });
 
-export { Video };
+export const Video = Object.defineProperty(VideoImpl, 'isAvailable', {
+  get: () => instance.isAvailable,
+  enumerable: true,
+  writable: false,
+  configurable: false,
+}) as typeof VideoImpl & { isAvailable: boolean };
+
 export type { VideoRef, VideoProps };


### PR DESCRIPTION
# Description

Fix video property type: `isAvailable`

AS-IS
<img width="723" height="143" alt="image" src="https://github.com/user-attachments/assets/34a4946f-052d-44ce-bf9c-25af1bff88ff" />

TO-BE
<img width="320" height="111" alt="스크린샷 2025-08-04 오후 10 17 00" src="https://github.com/user-attachments/assets/b068d241-f8e9-4ac0-beb1-24cfe2dad9d9" />
