### PR TITLE
feat(react-native): support initialScheme, support host

### DIFF
--- a/docs/ko/reference/react-native/config/defineConfig.md
+++ b/docs/ko/reference/react-native/config/defineConfig.md
@@ -19,6 +19,7 @@ Granite 애플리케이션의 주요 설정을 정의해요. `granite.config.ts`
 ```typescript
 function defineConfig({
   appName,
+  host,
   scheme,
   plugins,
   outdir,
@@ -28,7 +29,7 @@ function defineConfig({
   babel,
   esbuild,
   metro,
-}: GraniteConfigInput): Promise<GraniteConfigResponse>
+}: GraniteConfigInput): Promise<GraniteConfigResponse>;
 ```
 
 ## 매개변수
@@ -44,6 +45,8 @@ function defineConfig({
 설정 옵션에는 다음과 같은 것들이 있어요:
 
 - `appName`: URL에 표시될 앱의 고유 식별자예요 (예: `my-service`)
+- `host`: URL 스킴에서 호스트(`host`) 부분을 설정할 수 있어요. 선택 사항이며, 지정하지 않아도 동작해요. 이 값을 설정하면 `appName` 앞에 호스트가 포함된 경로로 구성돼요.  
+  예를 들어, `host`를 `super`로 설정하면 스킴 구조는 `{scheme}://super/{appName}`이 돼요.
 - `scheme`: 앱을 실행하기 위한 URL 스킴이에요 (예: `granite`)
 - `plugins`: 기능을 확장하기 위한 Granite 플러그인이에요
 - `outdir`: 빌드 파일이 출력될 위치예요 (기본값: `dist`)
@@ -71,6 +74,8 @@ import { hermes } from '@granite-js/plugin-hermes';
 export default defineConfig({
   // 마이크로서비스의 이름
   appName: 'my-app',
+  // (선택) URL Host 스킴
+  host: 'super',
   // 딥링크를 위한 URL 스킴
   scheme: 'granite',
   // 진입점 파일 경로

--- a/docs/reference/react-native/config/defineConfig.md
+++ b/docs/reference/react-native/config/defineConfig.md
@@ -7,8 +7,9 @@ sourcePath: packages/cli/src/config/defineConfig.ts
 Configures your Granite application by defining key settings in `granite.config.ts`.
 
 The configuration lets you specify:
+
 - How users will access your app through a URL scheme (e.g. `granite://`)
-- Your app's unique name that appears in the URL (e.g. `granite://my-service`) 
+- Your app's unique name that appears in the URL (e.g. `granite://my-service`)
 - Build settings for bundlers like ESBuild and Metro
 - Code transformation settings through Babel
 - Additional functionality through Granite plugins
@@ -18,6 +19,7 @@ The configuration lets you specify:
 ```typescript
 function defineConfig({
   appName,
+  host,
   scheme,
   plugins,
   outdir,
@@ -27,7 +29,7 @@ function defineConfig({
   babel,
   esbuild,
   metro,
-}: GraniteConfigInput): Promise<GraniteConfigResponse>
+}: GraniteConfigInput): Promise<GraniteConfigResponse>;
 ```
 
 ## Parameters
@@ -43,10 +45,12 @@ function defineConfig({
 The configuration options include:
 
 - `appName`: Your app's unique identifier that appears in URLs (e.g., 'my-service')
+- `host`: You can configure the `host` part of the URL scheme. This is optional, and the system works even if you don’t set it. If specified, the host is added before the `appName` in the path.  
+  For example, if you set the `host` to `super`, the scheme will be structured as `{scheme}://super/{appName}`.
 - `scheme`: URL scheme for launching your app (e.g., 'granite')
 - `plugins`: Granite plugins to enhance functionality
 - `outdir`: Where to output build files (defaults to 'dist')
-- `entryFile`: Your app's entry point (defaults to './src/_app.tsx')
+- `entryFile`: Your app's entry point (defaults to './src/\_app.tsx')
 - `cwd`: Working directory for build process (defaults to process.cwd())
 - `mpack`: Fine-tune mpack bundler behavior
 - `babel`: Customize Babel transpilation
@@ -70,6 +74,8 @@ import { hermes } from '@granite-js/plugin-hermes';
 export default defineConfig({
   // The name of your microservice
   appName: 'my-app',
+  // (Optional) The host name for your app (e.g. 'scheme://host/app-name')
+  host: 'super',
   // The URL scheme for deep linking
   scheme: 'granite',
   // Entry file path

--- a/packages/plugin-core/src/config/defineConfig.ts
+++ b/packages/plugin-core/src/config/defineConfig.ts
@@ -46,7 +46,7 @@ import { resolvePlugins } from '../utils/resolvePlugins';
  * export default defineConfig({
  *   // The name of your microservice
  *   appName: 'my-app',
- *   // The host name for your app (e.g. 'scheme://host/app-name')
+ *   // (Optional) The host name for your app (e.g. 'scheme://host/app-name')
  *   host: 'super',
  *   // The URL scheme for deep linking
  *   scheme: 'granite',

--- a/packages/plugin-core/src/config/defineConfig.ts
+++ b/packages/plugin-core/src/config/defineConfig.ts
@@ -23,6 +23,7 @@ import { resolvePlugins } from '../utils/resolvePlugins';
  * @param config - Configuration options
  * @param config.cwd - Working directory for build process (defaults to process.cwd())
  * @param config.appName - Your app's unique identifier
+ * @param config.host - Host name for your app (e.g. 'scheme://host/app-name')
  * @param config.scheme - URL scheme for launching your app (e.g. 'granite')
  * @param config.outdir - Where to output build files (defaults to 'dist')
  * @param config.entryFile - Your app's entry point (defaults to './src/_app.tsx')
@@ -45,6 +46,8 @@ import { resolvePlugins } from '../utils/resolvePlugins';
  * export default defineConfig({
  *   // The name of your microservice
  *   appName: 'my-app',
+ *   // The host name for your app (e.g. 'scheme://host/app-name')
+ *   host: 'super',
  *   // The URL scheme for deep linking
  *   scheme: 'granite',
  *   // Entry file path
@@ -58,6 +61,7 @@ export const defineConfig = async (config: GraniteConfig): Promise<CompleteGrani
   const parsed = pluginConfigSchema.parse(config);
   const cwd = parsed.cwd ?? getPackageRoot();
   const appName = parsed.appName;
+  const host = parsed.host ?? '';
   const scheme = parsed.scheme;
   const entryFile = path.resolve(cwd, parsed.entryFile);
   const outdir = path.join(cwd, parsed.outdir);
@@ -71,7 +75,7 @@ export const defineConfig = async (config: GraniteConfig): Promise<CompleteGrani
   };
 
   const { configs, pluginHooks } = await resolvePlugins(parsed.plugins);
-  const globalsScriptConfig = prepareGraniteGlobalsScript({ rootDir: cwd, appName, scheme });
+  const globalsScriptConfig = prepareGraniteGlobalsScript({ rootDir: cwd, appName, scheme, host });
   const mergedConfig = mergeConfig(parsedConfig, ...[globalsScriptConfig, ...configs].filter(isNotNil));
   const { metro, devServer, ...build } = mergedConfig ?? {};
 

--- a/packages/plugin-core/src/config/graniteGlobals.ts
+++ b/packages/plugin-core/src/config/graniteGlobals.ts
@@ -7,6 +7,7 @@ interface GraniteGlobalsConfig {
   rootDir: string;
   appName: string;
   scheme: string;
+  host: string;
 }
 
 export function prepareGraniteGlobalsScript(config: GraniteGlobalsConfig): PluginConfig {
@@ -34,9 +35,9 @@ function writeGraniteGlobalsScript(config: GraniteGlobalsConfig) {
   return filePath;
 }
 
-function getGraniteGlobalScript({ appName, scheme }: GraniteGlobalsConfig) {
+function getGraniteGlobalScript({ appName, scheme, host }: GraniteGlobalsConfig) {
   return [
     'global.__granite = global.__granite || {};',
-    `global.__granite.app = { name: ${JSON.stringify(appName)}, scheme: ${JSON.stringify(scheme)} };`,
+    `global.__granite.app = { name: ${JSON.stringify(appName)}, scheme: ${JSON.stringify(scheme)}, host: ${JSON.stringify(host)} };`,
   ].join('\n');
 }

--- a/packages/plugin-core/src/schema/pluginConfig.ts
+++ b/packages/plugin-core/src/schema/pluginConfig.ts
@@ -15,6 +15,7 @@ import type {
 export const pluginConfigSchema = z.object({
   cwd: z.string().default(process.cwd()),
   appName: z.string(),
+  host: z.string().optional(),
   scheme: z.string(),
   outdir: z.string().default('dist'),
   entryFile: z.string().default('./src/_app.tsx'),

--- a/packages/react-native/src/app/AppRoot.tsx
+++ b/packages/react-native/src/app/AppRoot.tsx
@@ -12,18 +12,27 @@ import type { GraniteProps } from './Granite';
 interface AppRootProps extends GraniteProps {
   container: ComponentType<PropsWithChildren<InitialProps>>;
   initialProps: InitialProps;
+  initialScheme: string;
 }
 
-export function AppRoot({ appName, context, container: Container, initialProps, router }: AppRootProps) {
+export function AppRoot({ appName, context, container: Container, initialProps, initialScheme, router }: AppRootProps) {
   const backEventState = useBackEventState();
   const scheme = global.__granite.app.scheme;
-  const baseScheme = `${scheme}://${appName}`;
+  const host = global.__granite.app.host;
+  const prefix = `${scheme}://${host.length > 0 ? `${host}/` : ''}${appName}`;
 
   return (
     <App {...initialProps}>
       <SafeAreaProvider>
         <BackEventProvider backEvent={backEventState}>
-          <Router context={context} initialProps={initialProps} container={Container} prefix={baseScheme} {...router} />
+          <Router
+            context={context}
+            initialProps={initialProps}
+            initialScheme={initialScheme}
+            container={Container}
+            prefix={prefix}
+            {...router}
+          />
         </BackEventProvider>
       </SafeAreaProvider>
     </App>

--- a/packages/react-native/src/app/Granite.tsx
+++ b/packages/react-native/src/app/Granite.tsx
@@ -5,6 +5,7 @@ import type { InitialProps } from '../initial-props';
 import type { RouterProps, RequireContext } from '../router';
 import { AppRoot } from './AppRoot';
 import { HostAppRoot } from './HostAppRoot';
+import { getSchemeUri } from '../constant-bridges';
 
 export interface GraniteProps {
   /**
@@ -24,6 +25,12 @@ export interface GraniteProps {
    * Configuration object to be passed to the router.
    */
   router?: RouterProps;
+
+  /**
+   * @description
+   * The initial scheme of the app.
+   */
+  initialScheme?: string;
 }
 
 const createApp = () => {
@@ -40,7 +47,7 @@ const createApp = () => {
   return {
     registerApp(
       AppContainer: ComponentType<PropsWithChildren<InitialProps>>,
-      { appName, context, router }: GraniteProps
+      { appName, context, router, initialScheme }: GraniteProps
     ): (initialProps: InitialProps) => JSX.Element {
       if (appName === ENTRY_BUNDLE_NAME) {
         throw new Error(`Reserved app name 'shared' cannot be used`);
@@ -51,6 +58,7 @@ const createApp = () => {
           <AppRoot
             container={AppContainer}
             initialProps={initialProps}
+            initialScheme={initialScheme ?? getSchemeUri()}
             appName={appName}
             context={context}
             router={router}

--- a/packages/react-native/src/router/Router.tsx
+++ b/packages/react-native/src/router/Router.tsx
@@ -55,6 +55,7 @@ export interface InternalRouterProps {
    */
   container: ComponentType<PropsWithChildren<InitialProps>>;
   initialProps: InitialProps;
+  initialScheme: string;
 }
 
 export type RouterProps = StackNavigatorProps & NavigationContainerProps;
@@ -122,6 +123,7 @@ export function Router({
   context,
   container: Container = Fragment,
   initialProps,
+  initialScheme,
   // Public props (NavigationContainer)
   navigationContainerRef,
   defaultScreenOption,
@@ -129,8 +131,13 @@ export function Router({
   // Public props (StackNavigator)
   ...navigationContainerProps
 }: InternalRouterProps & RouterProps): ReactElement {
-  const initialRouteName = useInitialRouteName(prefix);
-  const { Screens, linkingOptions } = useRouterControls({ prefix, context, screenContainer });
+  const initialRouteName = useInitialRouteName({ prefix, initialScheme });
+  const { Screens, linkingOptions } = useRouterControls({
+    prefix,
+    context,
+    screenContainer,
+    initialScheme,
+  });
 
   const ref = useMemo(() => navigationContainerRef ?? createNavigationContainerRef<any>(), [navigationContainerRef]);
 

--- a/packages/react-native/src/router/hooks/useInitialRouteName.tsx
+++ b/packages/react-native/src/router/hooks/useInitialRouteName.tsx
@@ -1,21 +1,15 @@
 import { Platform } from 'react-native';
-import { getSchemeUri } from '../../native-modules';
 
-export function useInitialRouteName(prefix: string) {
-  const initialScheme = getInitialScheme();
-  const pathname = initialScheme?.slice(prefix.length).split('?')[0];
+export function useInitialRouteName({ prefix, initialScheme }: { prefix: string; initialScheme: string }) {
+  const pathname = removeTrailingSlash(initialScheme).slice(prefix.length).split('?')[0];
   const shouldUseIndex = initialScheme == null || pathname?.length === 0;
 
   return shouldUseIndex ? '/' : pathname;
 }
-function getInitialScheme() {
-  const scheme = getSchemeUri();
 
-  /**
-   * Removes trailing '/' on Android.
-   */
+function removeTrailingSlash(scheme: string) {
   if (Platform.OS === 'android') {
-    return scheme?.replaceAll(/\/+$/g, '');
+    return scheme.replaceAll(/\/+$/g, '');
   }
 
   return scheme;

--- a/packages/react-native/src/router/hooks/useRouterControls.tsx
+++ b/packages/react-native/src/router/hooks/useRouterControls.tsx
@@ -1,6 +1,5 @@
 import { NavigationContainer } from '@granite-js/native/@react-navigation/native';
 import { useMemo, type ComponentProps, type ComponentType, type PropsWithChildren } from 'react';
-import { getSchemeUri } from '../../native-modules';
 import { StackNavigator } from '../components/StackNavigator';
 import { RESERVED_KEYWORDS } from '../constants';
 import { RequireContext } from '../types/RequireContext';
@@ -13,11 +12,17 @@ type NavigationContainerProps = ComponentProps<typeof NavigationContainer>;
 
 export interface RouterControlsConfig {
   prefix: string;
+  initialScheme: string;
   context: RequireContext;
   screenContainer?: ComponentType<PropsWithChildren<any>>;
 }
 
-export function useRouterControls({ prefix, context, screenContainer: ScreenContainer }: RouterControlsConfig) {
+export function useRouterControls({
+  prefix,
+  context,
+  screenContainer: ScreenContainer,
+  initialScheme,
+}: RouterControlsConfig) {
   const routeScreens = useMemo(() => getRouteScreens(context), [context]);
 
   const registerScreens = useMemo(() => {
@@ -56,17 +61,15 @@ export function useRouterControls({ prefix, context, screenContainer: ScreenCont
         screens: getScreenPathMapConfig(registerScreens),
       },
       async getInitialURL() {
-        const initialURL = getSchemeUri();
-
-        if (initialURL == null) {
+        if (initialScheme == null) {
           return;
         }
 
         /** @NOTE Korean paths need to be decoded. */
-        return decodeURI(initialURL);
+        return decodeURI(initialScheme);
       },
     };
-  }, [prefix, registerScreens]);
+  }, [initialScheme, prefix, registerScreens]);
 
   return { Screens, linkingOptions };
 }

--- a/packages/react-native/src/types/global.ts
+++ b/packages/react-native/src/types/global.ts
@@ -6,6 +6,7 @@ export interface GraniteGlobal {
   app: {
     name: string;
     scheme: string;
+    host: string;
   };
 }
 


### PR DESCRIPTION
## Features

- Add a `host` context to the scheme structure. You can configure it by passing a `host` value to `defineConfig`.
- Enable `initialScheme` to be provided from outside as well.

## docs

<img width="1402" height="811" alt="image" src="https://github.com/user-attachments/assets/3e3fe820-32fa-4612-b00d-6c6c6d6c390f" />
