### PR TITLE
fix(react-native): make backEventState a singleton

### DIFF
--- a/.changeset/proud-drinks-bow.md
+++ b/.changeset/proud-drinks-bow.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+Make backEventState a singleton

--- a/packages/react-native/src/app/AppRoot.tsx
+++ b/packages/react-native/src/app/AppRoot.tsx
@@ -2,7 +2,7 @@ import { SafeAreaProvider } from '@granite-js/native/react-native-safe-area-cont
 import type { ComponentType, PropsWithChildren } from 'react';
 import type { InitialProps } from '../initial-props';
 import { Router } from '../router';
-import { BackEventProvider, useBackEventState } from '../use-back-event';
+import { BackEventProvider } from '../use-back-event';
 import { App } from './App';
 import type { GraniteProps } from './Granite';
 import { getSchemePrefix } from '../utils/getSchemePrefix';
@@ -17,8 +17,6 @@ interface AppRootProps extends GraniteProps {
 }
 
 export function AppRoot({ appName, context, container: Container, initialProps, initialScheme, router }: AppRootProps) {
-  const backEventState = useBackEventState();
-
   const prefix = getSchemePrefix({
     appName,
     scheme: global.__granite.app.scheme,
@@ -28,7 +26,7 @@ export function AppRoot({ appName, context, container: Container, initialProps, 
   return (
     <App {...initialProps}>
       <SafeAreaProvider>
-        <BackEventProvider backEvent={backEventState}>
+        <BackEventProvider>
           <Router
             context={context}
             initialProps={initialProps}

--- a/packages/react-native/src/router/components/useRouterBackHandler.tsx
+++ b/packages/react-native/src/router/components/useRouterBackHandler.tsx
@@ -1,6 +1,6 @@
 import { NavigationContainerRefWithCurrent } from '@granite-js/native/@react-navigation/native';
 import { useCallback, useMemo } from 'react';
-import { useBackEventState } from '../../use-back-event';
+import { useBackEventContext } from '../../use-back-event';
 
 /**
  * @public
@@ -63,7 +63,7 @@ export function useInternalRouterBackHandler({
   navigationContainerRef: NavigationContainerRefWithCurrent<any>;
   onClose?: () => void;
 }) {
-  const { onBack, hasBackEvent } = useBackEventState();
+  const { hasBackEvent, onBack } = useBackEventContext();
   const canGoBack = !hasBackEvent;
 
   const handler = useCallback(() => {

--- a/packages/react-native/src/use-back-event/useBackEvent.tsx
+++ b/packages/react-native/src/use-back-event/useBackEvent.tsx
@@ -38,14 +38,10 @@ const BackEventContext = createContext<PrivateBackEventControls | null>(null);
  * </BackEventProvider>
  * ```
  */
-export function BackEventProvider({
-  children,
-  backEvent,
-}: {
-  children: ReactNode;
-  backEvent: PrivateBackEventControls;
-}) {
-  return <BackEventContext.Provider value={backEvent}>{children}</BackEventContext.Provider>;
+export function BackEventProvider({ children }: { children: ReactNode }) {
+  const backEventState = useBackEventState();
+
+  return <BackEventContext.Provider value={backEventState}>{children}</BackEventContext.Provider>;
 }
 
 /**
@@ -253,8 +249,5 @@ export function useBackEventContext() {
     throw new Error('useBackEvent must be used within a BackEventProvider');
   }
 
-  return {
-    onGoBack: context.onBack,
-    hasBackEvent: context.hasBackEvent,
-  };
+  return context;
 }

--- a/services/showcase/pages/showcase/use-back-event.tsx
+++ b/services/showcase/pages/showcase/use-back-event.tsx
@@ -1,0 +1,1 @@
+export { Route } from 'pages/showcase/use-back-event';

--- a/services/showcase/src/pages/showcase/use-back-event.tsx
+++ b/services/showcase/src/pages/showcase/use-back-event.tsx
@@ -1,0 +1,34 @@
+import { createRoute, useBackEvent } from '@granite-js/react-native';
+import { useCallback } from 'react';
+import { Alert, Button } from 'react-native';
+
+export const Route = createRoute('/showcase/use-back-event', {
+  validateParams: (params) => params,
+  component: UseBackEvent,
+});
+
+function UseBackEvent() {
+  const backEvent = useBackEvent();
+
+  const backHandler = useCallback(() => {
+    Alert.alert('back pressed!');
+  }, []);
+
+  return (
+    <>
+      <Button
+        title="Add BackEvent Callback"
+        onPress={() => {
+          backEvent.addEventListener(backHandler);
+        }}
+      />
+
+      <Button
+        title="Remove BackEvent Callback"
+        onPress={() => {
+          backEvent.removeEventListener(backHandler);
+        }}
+      />
+    </>
+  );
+}

--- a/services/showcase/src/router.gen.ts
+++ b/services/showcase/src/router.gen.ts
@@ -6,6 +6,7 @@ import { Route as _ShowcaseImageRoute } from '../pages/showcase/image';
 import { Route as _ShowcaseRoute } from '../pages/showcase';
 import { Route as _ShowcaseLottieRoute } from '../pages/showcase/lottie';
 import { Route as _ShowcaseStatusBarRoute } from '../pages/showcase/status-bar';
+import { Route as _ShowcaseUseBackEventRoute } from '../pages/showcase/use-back-event';
 import { Route as _ShowcaseVideoRoute } from '../pages/showcase/video';
 import { Route as _ShowcaseWebviewRoute } from '../pages/showcase/webview';
 
@@ -17,6 +18,7 @@ declare module '@granite-js/react-native' {
     '/showcase': ReturnType<typeof _ShowcaseRoute.useParams>;
     '/showcase/lottie': ReturnType<typeof _ShowcaseLottieRoute.useParams>;
     '/showcase/status-bar': ReturnType<typeof _ShowcaseStatusBarRoute.useParams>;
+    '/showcase/use-back-event': ReturnType<typeof _ShowcaseUseBackEventRoute.useParams>;
     '/showcase/video': ReturnType<typeof _ShowcaseVideoRoute.useParams>;
     '/showcase/webview': ReturnType<typeof _ShowcaseWebviewRoute.useParams>;
   }


### PR DESCRIPTION
## BugFix
- Make backEventState a singleton.

## Features
- Make UseBackEvent Test Page.

## Description 

The backEvent was being stored in separate states because the state was not shared.
I’ve refactored it into a singleton so that registered callbacks are shared properly.

## Test 

https://github.com/user-attachments/assets/1500aed4-5a72-4b28-a4f4-5110808dde04

