### PR TITLE
fix(react-native): Clarify 404 page error message

### DIFF
--- a/.changeset/warm-papers-camp.md
+++ b/.changeset/warm-papers-camp.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+Clarify error message for missing \_404 Page

--- a/packages/react-native/src/router/utils/screen.tsx
+++ b/packages/react-native/src/router/utils/screen.tsx
@@ -72,6 +72,12 @@ export function getScreenPathMapConfig(routeScreens: RouteScreen[]) {
     path: '',
   };
 
+  const notFoundPage = routeScreens.find((screen) => screen.path === '/_404');
+
+  if (notFoundPage == null) {
+    throw new Error('404 page not found. Please create a `_404.ts` or `_404.tsx` file in the `pages/*` folder.');
+  }
+
   // https://reactnavigation.org/docs/configuring-links/#handling-unmatched-routes-or-404
   screensConfig['/_404'] = {
     path: '*',


### PR DESCRIPTION
## Fix
- Clarify 404 page error message

## Description
- Clarify error message for missing _404 page (replacing generic TypeError)
  - as-is: `TypeError: Cannot read property 'props' of undefined`


  
  
## Test

<img width="346" height="155" alt="스크린샷 2025-08-12 오후 8 53 07" src="https://github.com/user-attachments/assets/5af5eb6f-9b00-4d03-ae81-f24b01486153" />