### PR TITLE
Show dev server URL on startup

### DIFF
--- a/.changeset/evil-sloths-do.md
+++ b/.changeset/evil-sloths-do.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/mpack': patch
+---
+
+Show dev server URL on startup

--- a/packages/mpack/src/operations/serve.ts
+++ b/packages/mpack/src/operations/serve.ts
@@ -6,6 +6,7 @@ import { createDebuggerMiddleware } from './createDebuggerMiddleware';
 import { DEV_SERVER_DEFAULT_HOST, DEV_SERVER_DEFAULT_PORT } from '../constants';
 import { getMetroConfig } from '../metro/getMetroConfig';
 import { printLogo } from '../utils/printLogo';
+import { printServerUrl } from '../utils/printServerUrl';
 import { getModule } from '../vendors';
 
 const debug = Debug('cli:start');
@@ -58,6 +59,7 @@ export async function runServer({
         case 'initialize_done':
           enableStdinWatchMode();
           await driver.devServer.post({ host, port });
+          printServerUrl({ host, port });
           await onServerReady?.();
           break;
 

--- a/packages/mpack/src/utils/printServerUrl.ts
+++ b/packages/mpack/src/utils/printServerUrl.ts
@@ -1,0 +1,3 @@
+export function printServerUrl({ host, port }: { host: string; port: number }) {
+  console.log(`Development server is running at http://${host}:${port}`);
+}


### PR DESCRIPTION
When I was running the dev server, I wasn’t sure which port to open locally.
I checked the docs, but it was also hard to find.
> Fortunately, find the hint on [docs](https://www.granite.run/guides/quick-start/create-your-app.html#_5-2-run-your-app)

These small changes make the development server print the URL to the console when initialized.

### Screenshot
<img width="773" height="457" alt="image" src="https://github.com/user-attachments/assets/be47d378-c183-4aed-8c4c-54396598e2bf" />
<img width="888" height="437" alt="image" src="https://github.com/user-attachments/assets/823b5333-2c3d-4299-9a13-9f9e9bbd02fa" />

