### PR TITLE
fix(mpack): update getId fields

### DIFF
--- a/.changeset/floppy-worlds-try.md
+++ b/.changeset/floppy-worlds-try.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/mpack': patch
+---
+
+fix getId generation

--- a/packages/mpack/src/server/DevServer.ts
+++ b/packages/mpack/src/server/DevServer.ts
@@ -17,7 +17,6 @@ import { WebSocketServerDelegate, WebSocketServerRouter } from './wss';
 import { DEV_SERVER_DEFAULT_HOST, DEV_SERVER_DEFAULT_PORT } from '../constants';
 import { logger, clientLogger } from '../logger';
 import { statusPlugin } from '../plugins/statusPlugin';
-import { persistentStorage } from '../shared/PersistentStorage';
 import { isDebugMode } from '../utils/isDebugMode';
 import { createProgressBar } from '../utils/progressBar';
 import { InspectorProxy } from '../vendors/@react-native/dev-middleware';
@@ -55,8 +54,6 @@ export class DevServer {
   async initialize() {
     logger.trace('DevServer.initialize');
     const { rootDir, buildConfig } = this.devServerOptions;
-
-    await persistentStorage.loadData();
     this.context = await this.createDevServerContext(rootDir, buildConfig);
   }
 

--- a/packages/mpack/src/shared/PersistentStorage.ts
+++ b/packages/mpack/src/shared/PersistentStorage.ts
@@ -1,16 +1,13 @@
-import * as fs from 'fs/promises';
+import * as fs from 'fs';
 import * as path from 'path';
 import { toMerged } from 'es-toolkit';
 import { MPACK_DATA_DIR } from '../constants';
 import { INTERNAL__Id } from '../types';
 
-/**
- * 파일 시스템에 저장되는 데이터 (캐싱된 메타 데이터)
- */
 interface PersistentData {
   [id: INTERNAL__Id]: {
     /**
-     * 번들링시 resolve 된 전체 모듈 수 (progress 계산에 사용)
+     * Resolved module count (used for progress bar progress calculation)
      */
     totalModuleCount: number;
   };
@@ -18,6 +15,10 @@ interface PersistentData {
 
 class PersistentStorage {
   private data: PersistentData = {};
+
+  constructor() {
+    this.loadData();
+  }
 
   getData() {
     return this.data;
@@ -27,15 +28,15 @@ class PersistentStorage {
     this.data = toMerged(this.data, newData);
   }
 
-  async loadData() {
+  loadData() {
     try {
-      await fs.access(MPACK_DATA_DIR, fs.constants.R_OK | fs.constants.W_OK);
+      fs.accessSync(MPACK_DATA_DIR, fs.constants.R_OK | fs.constants.W_OK);
     } catch {
-      await fs.mkdir(MPACK_DATA_DIR, { recursive: true });
+      fs.mkdirSync(MPACK_DATA_DIR, { recursive: true });
     }
 
     try {
-      this.data = JSON.parse(await fs.readFile(path.join(MPACK_DATA_DIR, '.mpack'), 'utf-8')) as PersistentData;
+      this.data = JSON.parse(fs.readFileSync(path.join(MPACK_DATA_DIR, '.mpack'), 'utf-8')) as PersistentData;
     } catch {
       // noop
     }
@@ -43,7 +44,7 @@ class PersistentStorage {
 
   async saveData() {
     try {
-      await fs.writeFile(path.join(MPACK_DATA_DIR, '.mpack'), JSON.stringify(this.data, null, 2), 'utf-8');
+      await fs.promises.writeFile(path.join(MPACK_DATA_DIR, '.mpack'), JSON.stringify(this.data, null, 2), 'utf-8');
     } catch {
       // noop
     }

--- a/packages/mpack/src/utils/getId.ts
+++ b/packages/mpack/src/utils/getId.ts
@@ -5,6 +5,19 @@ import type { BundlerConfig, INTERNAL__Id } from '../types';
 export function getId(bundleConfig: BundlerConfig) {
   // Hash the targets that affect code transformation
   return md5(
-    JSON.stringify([VERSION, bundleConfig.rootDir, bundleConfig.dev, bundleConfig.buildConfig])
+    JSON.stringify([
+      VERSION,
+      bundleConfig.rootDir,
+      bundleConfig.dev,
+      bundleConfig.buildConfig.resolver,
+      bundleConfig.buildConfig.transformer,
+      bundleConfig.buildConfig.platform,
+      bundleConfig.buildConfig.babel,
+      bundleConfig.buildConfig.swc,
+      bundleConfig.buildConfig.esbuild?.loader,
+      bundleConfig.buildConfig.esbuild?.resolveExtensions,
+      bundleConfig.buildConfig.esbuild?.mainFields,
+      bundleConfig.buildConfig.esbuild?.conditions,
+    ])
   ) as INTERNAL__Id;
 }


### PR DESCRIPTION
# Description

Fix ID generation to use only configurations that affect actual code transformation.

This resolves the issue where values like esbuild.footer.js change on every build (e.g., due to Sentry DebugId injection), causing a same ID to be generated each time.