### PR TITLE
fix(plugin-micro-frontend): define __esModule flag safety

### DIFF
--- a/packages/plugin-micro-frontend/src/runtime/exposeModule.ts
+++ b/packages/plugin-micro-frontend/src/runtime/exposeModule.ts
@@ -1,5 +1,5 @@
 import type { Container, Module } from './types';
-import { normalizePath } from './utils';
+import { normalizePath, toESM } from './utils';
 
 export function exposeModule(container: Container, exposeName: string, module: Module) {
   const normalizedExposeName = normalizePath(exposeName);
@@ -9,7 +9,7 @@ export function exposeModule(container: Container, exposeName: string, module: M
   }
 
   Object.defineProperty(container.exposeMap, normalizedExposeName, {
-    get: () => Object.assign(module, { __esModule: true }),
+    get: () => toESM(module),
     enumerable: true,
   });
 }

--- a/packages/plugin-micro-frontend/src/runtime/registerShared.ts
+++ b/packages/plugin-micro-frontend/src/runtime/registerShared.ts
@@ -1,11 +1,13 @@
-export function registerShared(libName: string, module: any) {
+import type { Module } from './types';
+import { toESM } from './utils';
+
+export function registerShared(libName: string, module: Module) {
   if (global.__MICRO_FRONTEND__.__SHARED__[libName]) {
     throw new Error(`'${libName}' already registered as a shared module`);
   }
 
   global.__MICRO_FRONTEND__.__SHARED__[libName] = {
-    // Add `__esModule` flag to ensure compatibility between ESM and CJS.
-    get: () => Object.assign(module, { __esModule: true }),
+    get: () => toESM(module),
     // Always mark as loaded because we don't support lazy loading yet.
     loaded: true,
   };

--- a/packages/plugin-micro-frontend/src/runtime/utils.ts
+++ b/packages/plugin-micro-frontend/src/runtime/utils.ts
@@ -1,3 +1,5 @@
+import type { Module } from './types';
+
 export function getContainer(instanceName: string) {
   const containerIndex = __MICRO_FRONTEND__.__INSTANCES__[instanceName];
 
@@ -40,4 +42,23 @@ export function importRemoteModule(remoteRequestPath: string) {
   }
 
   return module;
+}
+
+export function toESM(module: Module) {
+  if (module.__esModule) {
+    return module;
+  }
+
+  // Add `__esModule` flag to ensure compatibility between ESM and CJS.
+  return Object.defineProperties(module, {
+    __esModule: { value: true },
+    ...(module.default == null
+      ? {
+          default: {
+            value: module,
+            enumerable: true,
+          },
+        }
+      : null),
+  });
 }


### PR DESCRIPTION
# Description

In some third-party library modules, the `__esModule` property is either non-configurable (`configurable: false`, default option for `Object.defineProperty`) or exposed only via a getter, which prevents assigning to it. This change defines the `__esModule` flag only when the property actually needs to be defined.

Resolve below issues ->

<img width="406" height="117" alt="스크린샷 2025-08-20 오후 8 05 18" src="https://github.com/user-attachments/assets/0c63759b-46c2-462b-8d1a-3885a6d84c64" />

<img width="408" height="119" alt="스크린샷 2025-08-20 오후 8 05 42" src="https://github.com/user-attachments/assets/5685821a-b24b-4be4-a142-85fcaaec5d95" />
