### PR TITLE
fix(mpack): metafile generation

### DIFF
--- a/.changeset/pink-cows-hide.md
+++ b/.changeset/pink-cows-hide.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/mpack': patch
+---
+
+fix metafile generation

--- a/packages/mpack/src/operations/build.ts
+++ b/packages/mpack/src/operations/build.ts
@@ -14,7 +14,7 @@ import { isBuildSuccess } from '../utils/buildResult';
 import { getDefaultOutfileName } from '../utils/getDefaultOutfileName';
 import { printErrors } from '../utils/printErrors';
 import { isFulfilled, isRejected } from '../utils/promise';
-import { writeBundle } from '../utils/writeBundle';
+import { writeBundle, writeMetafile } from '../utils/writeBundle';
 
 type CommonBuildOptions = Omit<BundlerConfig, 'rootDir' | 'buildConfig'> & Pick<BuildConfig, 'platform' | 'outfile'>;
 
@@ -102,6 +102,10 @@ async function buildImpl(
 
   if (isBuildSuccess(buildResult)) {
     await writeBundle(buildResult.outfile, buildResult.bundle);
+
+    if (buildResult.metafile != null) {
+      await writeMetafile(buildResult.outfile, buildResult.metafile);
+    }
 
     const performanceSummary = Performance.getSummary();
     if (performanceSummary != null) {

--- a/packages/mpack/src/utils/writeBundle.ts
+++ b/packages/mpack/src/utils/writeBundle.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import type { BundleData } from '@granite-js/plugin-core';
+import type { Metafile } from 'esbuild';
 import { getSourcemapName } from './getSourcemapName';
 
 export async function writeBundle(outputPath: string, { source, sourcemap }: BundleData) {
@@ -13,6 +14,15 @@ export async function writeBundle(outputPath: string, { source, sourcemap }: Bun
     fs.writeFile(outputPath, source.contents, 'utf-8'),
     fs.writeFile(path.join(baseDirectory, getSourcemapName(basename)), sourcemap.contents, 'utf-8'),
   ]);
+}
+
+export async function writeMetafile(outputPath: string, metafile: Metafile) {
+  const outputDir = path.dirname(outputPath);
+  const extname = path.extname(outputPath);
+  const destination = path.join(outputDir, `${path.basename(outputPath, extname)}-meta.json`);
+
+  await createDirectories(outputDir);
+  await fs.writeFile(destination, JSON.stringify(metafile, null, 2), 'utf-8');
 }
 
 function createDirectories(directoryPath: string) {


### PR DESCRIPTION
# Descritpion

Generates esbuild's metafile correctly when execute build command with `--metafile` option.

<img width="605" height="221" alt="스크린샷 2025-08-22 오전 11 34 28" src="https://github.com/user-attachments/assets/bf6f48af-5e5c-44f7-8942-49291509d700" />
