### PR TITLE
feat: Add `dist/` folder to .gitignore template for granite-app

### DIFF
--- a/packages/create-granite-app/templates/granite-app/_gitignore
+++ b/packages/create-granite-app/templates/granite-app/_gitignore
@@ -1,4 +1,5 @@
 node_modules/
+dist/
 npm-debug.log
 
 .yarn/*


### PR DESCRIPTION
## Description

This PR adds the `dist/` folder to the `.gitignore` template for granite-app to prevent build artifacts from being committed to version control.

## Changes

- Added `dist/` to `packages/create-granite-app/templates/granite-app/_gitignore`

## Why

Build artifacts like the `dist/` folder should not be committed to version control as they are generated files that can be recreated from source code.

<img width="306" height="442" alt="image" src="https://github.com/user-attachments/assets/1af54f1a-c8c3-4d44-b54b-75458bd50d5c" />
