### PR TITLE
fix(react-native): handle undefined initialScheme in useInitialRouteName hook

### DIFF
--- a/packages/react-native/src/router/hooks/useInitialRouteName.tsx
+++ b/packages/react-native/src/router/hooks/useInitialRouteName.tsx
@@ -1,8 +1,12 @@
 import { Platform } from 'react-native';
 
-export function useInitialRouteName({ prefix, initialScheme }: { prefix: string; initialScheme: string }) {
+export function useInitialRouteName({ prefix, initialScheme }: { prefix: string; initialScheme?: string }) {
+  if (!initialScheme) {
+    return '/';
+  }
+
   const pathname = removeTrailingSlash(initialScheme).slice(prefix.length).split('?')[0];
-  const shouldUseIndex = initialScheme == null || pathname?.length === 0;
+  const shouldUseIndex = pathname?.length === 0;
 
   return shouldUseIndex ? '/' : pathname;
 }


### PR DESCRIPTION
## Description

This PR fixes a runtime error that occurs when `initialScheme` is `undefined` or `null` in the `useInitialRouteName` hook.

## Problem

When `initialScheme` is `undefined` or `null`, calling `.slice()` on it throws a runtime error:
```
Render Error: Cannot read property 'slice' of undefined
```

<img width="458" height="968" alt="image" src="https://github.com/user-attachments/assets/7736c04c-2351-4a09-ad58-4261432af896" />


## Solution

- Made `initialScheme` parameter optional with proper type safety (`string | undefined`)
- Added early return for undefined `initialScheme` to prevent the slice() error
- Simplified the `shouldUseIndex` logic by removing redundant null check
- Added proper TypeScript types for better type safety
