### PR TITLE
fix(react-native): avoid multiple app registrations without throwing errors

### DIFF
--- a/.changeset/fair-snakes-drive.md
+++ b/.changeset/fair-snakes-drive.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+avoid multiple app registrations without throwing errors

--- a/packages/react-native/src/app/Granite.tsx
+++ b/packages/react-native/src/app/Granite.tsx
@@ -44,7 +44,8 @@ const createApp = () => {
 
   function registerComponent(appKey: string, component: React.ComponentType<any>): string {
     if (AppRegistry.getAppKeys().includes(appKey)) {
-      throw new Error(`App with key '${appKey}' already registered`);
+      // `AppRegistry.registerComponent` returns the app key.
+      return appKey;
     }
 
     return AppRegistry.registerComponent(appKey, () => component);


### PR DESCRIPTION
# Description

Fix an issue where triggering HMR caused changes to propagate and led to errors.

<img width="470" height="928" alt="스크린샷 2025-09-03 오후 4 00 59" src="https://github.com/user-attachments/assets/79fa11de-00eb-45b7-a648-596659ccb276" />
