### PR TITLE
fix: return _404 when initialScheme doesn't match prefix

### DIFF
--- a/.changeset/sour-rice-repeat.md
+++ b/.changeset/sour-rice-repeat.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+return \_404 when initialScheme doesn't match prefix

--- a/packages/react-native/src/router/hooks/useInitialRouteName.tsx
+++ b/packages/react-native/src/router/hooks/useInitialRouteName.tsx
@@ -6,7 +6,6 @@ export function useInitialRouteName({ prefix, initialScheme }: { prefix: string;
   }
 
   if (!initialScheme.startsWith(prefix)) {
-    console.error("initialScheme's wrong in useInitialRouteName");
     return '_404';
   }
 

--- a/packages/react-native/src/router/hooks/useInitialRouteName.tsx
+++ b/packages/react-native/src/router/hooks/useInitialRouteName.tsx
@@ -5,6 +5,11 @@ export function useInitialRouteName({ prefix, initialScheme }: { prefix: string;
     return '/';
   }
 
+  if (!initialScheme.startsWith(prefix)) {
+    console.error("initialScheme's wrong in useInitialRouteName");
+    return '_404';
+  }
+
   const pathname = removeTrailingSlash(initialScheme).slice(prefix.length).split('?')[0];
   const shouldUseIndex = pathname?.length === 0;
 


### PR DESCRIPTION
 ## Summary
  - Add validation to return '_404' route when initialScheme doesn't start with the expected prefix

  ## Changes
  - Modified `useInitialRouteName` hook to validate initialScheme against prefix before processing
  - Returns '_404' route for mismatched schemes instead of proceeding with invalid pathname extraction

  ## Why
  - Prevents unexpected routing behavior when deep link schemes don't match the app's expected prefix
  - Provides better error handling and debugging information for invalid deep link scenarios