### PR TITLE
feat(react-native): add getInitialUrl

### DIFF
--- a/packages/react-native/src/app/AppRoot.tsx
+++ b/packages/react-native/src/app/AppRoot.tsx
@@ -1,7 +1,7 @@
 import { SafeAreaProvider } from '@granite-js/native/react-native-safe-area-context';
 import type { ComponentType, PropsWithChildren } from 'react';
 import type { InitialProps } from '../initial-props';
-import { Router } from '../router';
+import { Router, type InternalRouterProps } from '../router';
 import { BackEventProvider } from '../use-back-event';
 import { App } from './App';
 import type { GraniteProps } from './Granite';
@@ -16,6 +16,7 @@ interface AppRootProps extends GraniteProps {
   initialProps: InitialProps;
   initialScheme: string;
   setIosSwipeGestureEnabled?: ({ isEnabled }: { isEnabled: boolean }) => void;
+  getInitialUrl: InternalRouterProps['getInitialUrl'];
 }
 
 export function AppRoot({
@@ -26,6 +27,7 @@ export function AppRoot({
   initialScheme,
   router,
   setIosSwipeGestureEnabled,
+  getInitialUrl,
 }: AppRootProps) {
   const prefix = getSchemePrefix({
     appName,
@@ -45,6 +47,7 @@ export function AppRoot({
               container={Container}
               prefix={prefix}
               setIosSwipeGestureEnabled={setIosSwipeGestureEnabled}
+              getInitialUrl={getInitialUrl}
               {...router}
             />
           </BackEventProvider>

--- a/packages/react-native/src/app/Granite.tsx
+++ b/packages/react-native/src/app/Granite.tsx
@@ -37,6 +37,14 @@ export interface GraniteProps {
    * The function to set the iOS swipe gesture enabled.
    */
   setIosSwipeGestureEnabled?: ({ isEnabled }: { isEnabled: boolean }) => void;
+
+  /**
+   * @description
+   * The function to provide the initial URL to router.
+   * @param initialScheme The initial scheme of the app.
+   * @returns
+   */
+  getInitialUrl?: (initialScheme: string) => string | undefined | Promise<string | undefined>;
 }
 
 const createApp = () => {
@@ -54,7 +62,7 @@ const createApp = () => {
   return {
     registerApp(
       AppContainer: ComponentType<PropsWithChildren<InitialProps>>,
-      { appName, context, router, initialScheme, setIosSwipeGestureEnabled }: GraniteProps
+      { appName, context, router, initialScheme, setIosSwipeGestureEnabled, getInitialUrl }: GraniteProps
     ): (initialProps: InitialProps) => JSX.Element {
       if (appName === ENTRY_BUNDLE_NAME) {
         throw new Error(`Reserved app name 'shared' cannot be used`);
@@ -67,6 +75,7 @@ const createApp = () => {
             initialProps={initialProps}
             initialScheme={initialScheme ?? getSchemeUri()}
             setIosSwipeGestureEnabled={setIosSwipeGestureEnabled}
+            getInitialUrl={getInitialUrl}
             appName={appName}
             context={context}
             router={router}

--- a/packages/react-native/src/router/Router.tsx
+++ b/packages/react-native/src/router/Router.tsx
@@ -15,7 +15,7 @@ import { CanGoBackGuard } from './components/CanGoBackGuard';
 import { StackNavigator } from './components/StackNavigator';
 import { useInternalRouterBackHandler } from './components/useRouterBackHandler';
 import { useInitialRouteName } from './hooks/useInitialRouteName';
-import { useRouterControls } from './hooks/useRouterControls';
+import { useRouterControls, type RouterControlsConfig } from './hooks/useRouterControls';
 import { RequireContext } from './types';
 import { BASE_STACK_NAVIGATOR_STYLE } from './types/screen-option';
 
@@ -57,6 +57,7 @@ export interface InternalRouterProps {
   initialProps: InitialProps;
   initialScheme: string;
   setIosSwipeGestureEnabled?: ({ isEnabled }: { isEnabled: boolean }) => Promise<void> | void;
+  getInitialUrl?: RouterControlsConfig['getInitialUrl'];
 }
 
 export type RouterProps = StackNavigatorProps & NavigationContainerProps;
@@ -131,6 +132,7 @@ export function Router({
   screenContainer,
   // Public props (StackNavigator)
   setIosSwipeGestureEnabled,
+  getInitialUrl,
   ...navigationContainerProps
 }: InternalRouterProps & RouterProps): ReactElement {
   const initialRouteName = useInitialRouteName({ prefix, initialScheme });
@@ -139,6 +141,7 @@ export function Router({
     context,
     screenContainer,
     initialScheme,
+    getInitialUrl,
   });
 
   const ref = useMemo(() => navigationContainerRef ?? createNavigationContainerRef<any>(), [navigationContainerRef]);

--- a/packages/react-native/src/router/hooks/useRouterControls.tsx
+++ b/packages/react-native/src/router/hooks/useRouterControls.tsx
@@ -14,6 +14,7 @@ export interface RouterControlsConfig {
   prefix: string;
   initialScheme: string;
   context: RequireContext;
+  getInitialUrl?: (initialScheme: string) => string | undefined | Promise<string | undefined>;
   screenContainer?: ComponentType<PropsWithChildren<any>>;
 }
 
@@ -21,6 +22,7 @@ export function useRouterControls({
   prefix,
   context,
   screenContainer: ScreenContainer,
+  getInitialUrl = defaultGetInitialUrl,
   initialScheme,
 }: RouterControlsConfig) {
   const routeScreens = useMemo(() => getRouteScreens(context), [context]);
@@ -61,15 +63,19 @@ export function useRouterControls({
         screens: getScreenPathMapConfig(registerScreens),
       },
       async getInitialURL() {
-        if (initialScheme == null) {
-          return;
-        }
-
-        /** @NOTE Korean paths need to be decoded. */
-        return decodeURI(initialScheme);
+        return (getInitialUrl ?? defaultGetInitialUrl)(initialScheme);
       },
     };
-  }, [initialScheme, prefix, registerScreens]);
+  }, [initialScheme, prefix, registerScreens, getInitialUrl]);
 
   return { Screens, linkingOptions };
+}
+
+function defaultGetInitialUrl(initialScheme: string) {
+  if (initialScheme == null) {
+    return;
+  }
+
+  /** @NOTE Korean paths need to be decoded. */
+  return decodeURI(initialScheme);
 }


### PR DESCRIPTION
# Description

The router's `getInitialUrl` includes URL decoding by default.
Add an option to allow per-app control instead of using the default behavior.

Test scheme: `granite://showcase?url=https%3A%2F%2Ftoss.im%3Ftest%3Dhello%252Bworld`

(Before: `url` param always decoded)
<img width="534" height="69" alt="스크린샷 2025-09-22 오후 3 13 16" src="https://github.com/user-attachments/assets/324954d7-a586-4208-afd7-4da9473381f1" />

(After: Keep the `url` param encoded)
<img width="531" height="72" alt="스크린샷 2025-09-22 오후 3 14 17" src="https://github.com/user-attachments/assets/b2158b98-9409-4aae-b500-ea1cdf6eb478" />


