### PR TITLE
refactor(native): update exports for lottie-react-native, react-native-fast-image, react-native-pager-view, react-native-video

### DIFF
--- a/.changeset/seven-plants-wait.md
+++ b/.changeset/seven-plants-wait.md
@@ -1,0 +1,7 @@
+---
+'@granite-js/native': patch
+---
+
+feat(native): add named exports for native modules
+
+Add explicit named exports for lottie-react-native, react-native-fast-image, react-native-pager-view, and react-native-video to improve tree-shaking and provide better TypeScript support.

--- a/packages/native/src/lottie-react-native.ts
+++ b/packages/native/src/lottie-react-native.ts
@@ -1,2 +1,5 @@
-export { default } from 'lottie-react-native';
+import LottieView from 'lottie-react-native';
+
 export * from 'lottie-react-native';
+export { LottieView };
+export default LottieView;

--- a/packages/native/src/react-native-fast-image.ts
+++ b/packages/native/src/react-native-fast-image.ts
@@ -1,2 +1,5 @@
-export { default } from 'react-native-fast-image';
+import FastImage from 'react-native-fast-image';
+
 export * from 'react-native-fast-image';
+export { FastImage };
+export default FastImage;

--- a/packages/native/src/react-native-pager-view.ts
+++ b/packages/native/src/react-native-pager-view.ts
@@ -1,2 +1,5 @@
-export { default } from 'react-native-pager-view';
+import PagerView from 'react-native-pager-view';
+
 export * from 'react-native-pager-view';
+export { PagerView };
+export default PagerView;

--- a/packages/native/src/react-native-video.ts
+++ b/packages/native/src/react-native-video.ts
@@ -1,2 +1,5 @@
-export { default } from 'react-native-video';
+import Video from 'react-native-video';
+
 export * from 'react-native-video';
+export { Video };
+export default Video;


### PR DESCRIPTION
## Summary

This PR adds explicit named exports for native modules in `@granite-js/native` package to improve tree-shaking and provide better TypeScript support.

## Changes

- **lottie-react-native**: Add named export `LottieView` alongside default export
- **react-native-fast-image**: Add named export `FastImage` alongside default export  
- **react-native-pager-view**: Add named export `PagerView` alongside default export
- **react-native-video**: Add named export `Video` alongside default export

## Before
```typescript
export { default } from 'lottie-react-native';
export * from 'lottie-react-native';
```

## After
```typescript
import LottieView from 'lottie-react-native';

export * from 'lottie-react-native';
export { LottieView };
export default LottieView;
```

## Benefits

- **Better tree-shaking**: Explicit named exports allow bundlers to eliminate unused code more effectively
- **Improved TypeScript support**: Better type inference and autocomplete for named imports
- **Consistent API**: All native modules now follow the same export pattern
- **Backward compatibility**: Default exports are still available for existing code

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [x] No breaking changes to existing API
- [x] All native modules maintain backward compatibility