### PR TITLE
fix: release `semaphore` in `MetroBuildUtils.buildAll`

### DIFF
--- a/packages/mpack/src/metro/build.ts
+++ b/packages/mpack/src/metro/build.ts
@@ -54,7 +54,7 @@ export async function buildAll(
       try {
         const buildResult = await buildImpl(config, options);
         buildResults.push(buildResult);
-      } catch {
+      } finally {
         semaphore.release();
       }
     })


### PR DESCRIPTION
Metro bulid gets stuck if `concurrency` is smaller than `optionsList.length` because `semaphore` is never released unless the build fails. So this PR makes sure that `semaphore` is always released after the build.