### PR TITLE
fix: update `ScrollViewInertialBackground` default color to respect background

### DIFF
--- a/packages/react-native/src/scroll-view-inertial-background/ScrollViewInertialBackground.tsx
+++ b/packages/react-native/src/scroll-view-inertial-background/ScrollViewInertialBackground.tsx
@@ -96,4 +96,4 @@ function HiddenView({ style, pointerEvents = 'none', ...props }: ComponentProps<
  * Gradient value for BottomCTA. Set as a fixed value to avoid peerDeps.
  */
 const GRADIENT_HEIGHT = 37;
-const DEFAULT_BACKGROUND_COLOR = '#ffffff';
+const DEFAULT_BACKGROUND_COLOR = 'transparent';


### PR DESCRIPTION
Update the default color of `ScrollViewInertialBackground` to `transparent` since it can cause strange behavior in non-white backgrounds.


https://github.com/user-attachments/assets/fa385ae7-f125-4f2d-9759-db3d0c717ba9



