### PR TITLE
feat(react-native): add useKeyboardHeight

### DIFF
--- a/.changeset/funky-pants-see.md
+++ b/.changeset/funky-pants-see.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+feat: add useKeyboardHeight

--- a/packages/react-native/src/keyboard/getInitialKeyboardHeight.ts
+++ b/packages/react-native/src/keyboard/getInitialKeyboardHeight.ts
@@ -5,7 +5,7 @@ export function getInitialKeyboardHeight() {
     if (Platform.OS === 'android' && !isNewArchEnabled()) {
       return 0;
     }
-  
+
     /**
      * Branch handling for React Native 0.68.0 version where `metrics()` does not exist
      */

--- a/packages/react-native/src/keyboard/getInitialKeyboardHeight.ts
+++ b/packages/react-native/src/keyboard/getInitialKeyboardHeight.ts
@@ -1,0 +1,21 @@
+import { Platform } from "react-native";
+import { isNewArchEnabled } from "../utils/isNewArchEnabled";
+
+export function getInitialKeyboardHeight() {
+    if (Platform.OS === 'android' && !isNewArchEnabled()) {
+      return 0;
+    }
+  
+    /**
+     * Branch handling for React Native 0.68.0 version where `metrics()` does not exist
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    if (typeof Keyboard?.metrics === 'function') {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return Keyboard.metrics()?.height ?? 0;
+    } else {
+      return 0;
+    }
+}

--- a/packages/react-native/src/keyboard/getInitialKeyboardHeight.ts
+++ b/packages/react-native/src/keyboard/getInitialKeyboardHeight.ts
@@ -1,4 +1,4 @@
-import { Platform } from "react-native";
+import { Platform, Keyboard } from "react-native";
 import { isNewArchEnabled } from "../utils/isNewArchEnabled";
 
 export function getInitialKeyboardHeight() {

--- a/packages/react-native/src/keyboard/getKeyboardEventNames.ts
+++ b/packages/react-native/src/keyboard/getKeyboardEventNames.ts
@@ -1,0 +1,20 @@
+import { Platform } from "react-native";
+import { isNewArchEnabled } from "../utils/isNewArchEnabled";
+
+export function getKeyboardEventNames() {
+    if (Platform.OS === 'ios') {
+      return {
+        show: 'keyboardWillShow',
+        hide: 'keyboardWillHide',
+      } as const;
+    }
+  
+    if (Platform.OS === 'android' && isNewArchEnabled()) {
+      return {
+        show: 'keyboardDidShow',
+        hide: 'keyboardDidHide',
+      } as const;
+    }
+  
+    return null;
+  }

--- a/packages/react-native/src/keyboard/getKeyboardEventNames.ts
+++ b/packages/react-native/src/keyboard/getKeyboardEventNames.ts
@@ -8,13 +8,13 @@ export function getKeyboardEventNames() {
         hide: 'keyboardWillHide',
       } as const;
     }
-  
+
     if (Platform.OS === 'android' && isNewArchEnabled()) {
       return {
         show: 'keyboardDidShow',
         hide: 'keyboardDidHide',
       } as const;
     }
-  
+
     return null;
   }

--- a/packages/react-native/src/keyboard/index.ts
+++ b/packages/react-native/src/keyboard/index.ts
@@ -1,2 +1,3 @@
 export { KeyboardAboveView } from './KeyboardAboveView';
 export { useKeyboardAnimatedHeight } from './useKeyboardAnimatedHeight';
+export { useKeyboardHeight } from './useKeyboardHeight';

--- a/packages/react-native/src/keyboard/useKeyboardAnimatedHeight.tsx
+++ b/packages/react-native/src/keyboard/useKeyboardAnimatedHeight.tsx
@@ -1,43 +1,7 @@
 import { useEffect, useRef } from 'react';
-import { Animated, Keyboard, Platform } from 'react-native';
-import { isNewArchEnabled } from '../utils/isNewArchEnabled';
-
-function getKeyboardEventNames() {
-  if (Platform.OS === 'ios') {
-    return {
-      show: 'keyboardWillShow',
-      hide: 'keyboardWillHide',
-    } as const;
-  }
-
-  if (Platform.OS === 'android' && isNewArchEnabled()) {
-    return {
-      show: 'keyboardDidShow',
-      hide: 'keyboardDidHide',
-    } as const;
-  }
-
-  return null;
-}
-
-function getInitialKeyboardHeight() {
-  if (Platform.OS === 'android' && !isNewArchEnabled()) {
-    return 0;
-  }
-
-  /**
-   * Branch handling for React Native 0.68.0 version where `metrics()` does not exist
-   */
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  if (typeof Keyboard?.metrics === 'function') {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return Keyboard.metrics()?.height ?? 0;
-  } else {
-    return 0;
-  }
-}
+import { Animated, Keyboard } from 'react-native';
+import { getInitialKeyboardHeight } from './getInitialKeyboardHeight';
+import { getKeyboardEventNames } from './getKeyboardEventNames';
 
 /**
  * @category Hooks

--- a/packages/react-native/src/keyboard/useKeyboardHeight.tsx
+++ b/packages/react-native/src/keyboard/useKeyboardHeight.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { Keyboard } from 'react-native';
+import { getInitialKeyboardHeight } from './getInitialKeyboardHeight';
+import { getKeyboardEventNames } from './getKeyboardEventNames';
+
+/**
+ * @category Hooks
+ * @name useKeyboardHeight
+ * @description
+ * A Hook that returns the current keyboard height as a number when the keyboard appears or disappears. Unlike `useKeyboardAnimatedHeight`, this Hook does not animate the value — it simply reflects the latest keyboard height.
+ *
+ * This Hook uses `keyboardWillShow`/`keyboardWillHide` on iOS, and `keyboardDidShow`/`keyboardDidHide` on Android when React Native New Architecture is enabled. On Android Old Architecture, it always returns `0`.
+ *
+ * @returns {number} - The current keyboard height.
+ * @example
+ * ```typescript
+ * const keyboardHeight = useKeyboardHeight();
+ *
+ * <View style={{ marginBottom: keyboardHeight }}>
+ *  {children}
+ * </View>
+ * ```
+ */
+export function useKeyboardHeight(): number {
+  const [keyboardHeight, setKeyboardHeight] = useState<number>(getInitialKeyboardHeight);
+
+  useEffect(() => {
+    const keyboardEventNames = getKeyboardEventNames();
+
+    if (keyboardEventNames == null) {
+      return;
+    }
+
+    const showSubscription = Keyboard.addListener(keyboardEventNames.show, (event) => {
+      setKeyboardHeight(event.endCoordinates.height);
+    });
+
+    const hideSubscription = Keyboard.addListener(keyboardEventNames.hide, () => {
+      setKeyboardHeight(0);
+    });
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
+
+  return keyboardHeight;
+}


### PR DESCRIPTION
## Summary
- add `useKeyboardHeight` to expose the current keyboard height as a plain number
- extract shared keyboard helpers so `useKeyboardAnimatedHeight` and the new hook reuse the same event and initial height logic