### PR TITLE
chore: bump react-navigation

### DIFF
--- a/.changeset/silver-candles-start.md
+++ b/.changeset/silver-candles-start.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/native': patch
+---
+
+chore: bump react-navigation

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,9 +5,9 @@ catalogs:
     '@babel/plugin-transform-flow-strip-types': 7.27.1
     '@react-native/babel-plugin-codegen': 0.84.0
     '@react-native/babel-preset': 0.84.0
-    '@react-navigation/elements': 2.9.12
-    '@react-navigation/native': 7.2.0
-    '@react-navigation/native-stack': 7.14.7
+    '@react-navigation/elements': 2.9.14
+    '@react-navigation/native': 7.2.2
+    '@react-navigation/native-stack': 7.14.10
     '@shopify/flash-list': 2.2.2
     '@types/react': 19.2.0
     '@types/react-dom': 19.2.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -8408,9 +8408,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-navigation/core@npm:^7.17.0":
-  version: 7.17.0
-  resolution: "@react-navigation/core@npm:7.17.0"
+"@react-navigation/core@npm:^7.17.2":
+  version: 7.17.2
+  resolution: "@react-navigation/core@npm:7.17.2"
   dependencies:
     "@react-navigation/routers": "npm:^7.5.3"
     escape-string-regexp: "npm:^4.0.0"
@@ -8422,53 +8422,53 @@ __metadata:
     use-sync-external-store: "npm:^1.5.0"
   peerDependencies:
     react: ">= 18.2.0"
-  checksum: 10c0/fddf1e5806b8b0acad9fa99fe53ca5690111aaaa7677365e4c3181c0ba08b1b3762a063e42fc689bdbc38055ae8dc6fe9e942b88bda645523fde0e1cbc395527
+  checksum: 10c0/df1889769e90f85b71605070818b22bd9967f5fd0572187d31e6a17386339336c8890b9c7ba505854382426cb3b5be8d03ea4684da4ad5be2cdae828302b98a0
   languageName: node
   linkType: hard
 
-"@react-navigation/elements@npm:2.9.12, @react-navigation/elements@npm:^2.9.12":
-  version: 2.9.12
-  resolution: "@react-navigation/elements@npm:2.9.12"
+"@react-navigation/elements@npm:2.9.14, @react-navigation/elements@npm:^2.9.14":
+  version: 2.9.14
+  resolution: "@react-navigation/elements@npm:2.9.14"
   dependencies:
     color: "npm:^4.2.3"
     use-latest-callback: "npm:^0.2.4"
     use-sync-external-store: "npm:^1.5.0"
   peerDependencies:
     "@react-native-masked-view/masked-view": ">= 0.2.0"
-    "@react-navigation/native": ^7.2.0
+    "@react-navigation/native": ^7.2.2
     react: ">= 18.2.0"
     react-native: "*"
     react-native-safe-area-context: ">= 4.0.0"
   peerDependenciesMeta:
     "@react-native-masked-view/masked-view":
       optional: true
-  checksum: 10c0/78dff00d79657dd47f7be254db2c4d3c37406f18e6ff6d650be31d5cbfe0c9e9bd28605e7880e174ae6d11ecbb41b87f7a4620b5cce899e135025a621e44a8f0
+  checksum: 10c0/c2602f5be41caaad8ea81a9bdfde654d4a89d83c627a910f5d166bd8cac2700399fce805f6bf15faaf06c2bbc776325269bc0ec1fbbe917b615e17a0a5d371e1
   languageName: node
   linkType: hard
 
-"@react-navigation/native-stack@npm:7.14.7":
-  version: 7.14.7
-  resolution: "@react-navigation/native-stack@npm:7.14.7"
+"@react-navigation/native-stack@npm:7.14.10":
+  version: 7.14.10
+  resolution: "@react-navigation/native-stack@npm:7.14.10"
   dependencies:
-    "@react-navigation/elements": "npm:^2.9.12"
+    "@react-navigation/elements": "npm:^2.9.14"
     color: "npm:^4.2.3"
     sf-symbols-typescript: "npm:^2.1.0"
     warn-once: "npm:^0.1.1"
   peerDependencies:
-    "@react-navigation/native": ^7.2.0
+    "@react-navigation/native": ^7.2.2
     react: ">= 18.2.0"
     react-native: "*"
     react-native-safe-area-context: ">= 4.0.0"
     react-native-screens: ">= 4.0.0"
-  checksum: 10c0/51b45818dac5b7295cb0f36f8d24e1c9ab993bc50004f538781e714a1d7277804c2af30965e07dae5f4ff13d5e5e6677f364f19c2a3705619c9449f017842a86
+  checksum: 10c0/0ec90836475a9d3988d642504868589d0e00bc9a4955e81806d942a0614fe5081f684c83e4b493c07bdf6a61b8676cfca41a5a374cf84bf76289fdb24cc8cd7b
   languageName: node
   linkType: hard
 
-"@react-navigation/native@npm:7.2.0":
-  version: 7.2.0
-  resolution: "@react-navigation/native@npm:7.2.0"
+"@react-navigation/native@npm:7.2.2":
+  version: 7.2.2
+  resolution: "@react-navigation/native@npm:7.2.2"
   dependencies:
-    "@react-navigation/core": "npm:^7.17.0"
+    "@react-navigation/core": "npm:^7.17.2"
     escape-string-regexp: "npm:^4.0.0"
     fast-deep-equal: "npm:^3.1.3"
     nanoid: "npm:^3.3.11"
@@ -8476,7 +8476,7 @@ __metadata:
   peerDependencies:
     react: ">= 18.2.0"
     react-native: "*"
-  checksum: 10c0/49f4d6ebf4c78148299ee1974db24ac748726c0e01006ace243fe8078877caa0e0c2d888b0d626f364524ca00abe2298f005944808942c5bc8f5880116294f63
+  checksum: 10c0/3ca6e742da2ed4110b81fc008536ca62f07cdf49b368e9b7f73cbc25ad86603f87f14d08492bf1de2647ca6f4cf7141bec4fa3cd76961fa2fa22f83d0f805e83
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
```
➤ YN0060: │ @react-navigation/native is listed by your project with version 7.2.0 (p43674c), which doesn't satisfy what @react-navigation/elements (via @react-navigation/native-stack) and other dependencies request (^7.2.2).
Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
```