### PR TITLE
feat(vitest): remove polyfill (use consumer's source)

### DIFF
--- a/.changeset/spotty-streets-find.md
+++ b/.changeset/spotty-streets-find.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/vitest': patch
+---
+
+feat: remove dependency(@react-native/js-polyfill)

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -3,8 +3,6 @@
   "version": "1.0.20",
   "type": "module",
   "description": "Vitest helpers for React Native",
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
@@ -12,21 +10,9 @@
     "directory": "packages/vitest"
   },
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "./setup": {
-      "types": "./dist/setup.d.ts",
-      "import": "./dist/setup.js",
-      "default": "./dist/setup.js"
-    },
-    "./react-native-runtime": {
-      "types": "./dist/reactNativeRuntime.d.ts",
-      "import": "./dist/reactNativeRuntime.js",
-      "default": "./dist/reactNativeRuntime.js"
-    },
+    ".": "./dist/index.js",
+    "./reactNativeRuntime": "./dist/reactNativeRuntime.js",
+    "./setup": "./dist/setup.js",
     "./package.json": "./package.json"
   },
   "files": [
@@ -40,7 +26,6 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@react-native/js-polyfills": "0.84.0",
     "fast-flow-transform": "0.0.3"
   },
   "devDependencies": {

--- a/packages/vitest/src/reactNativeRuntime.spec.ts
+++ b/packages/vitest/src/reactNativeRuntime.spec.ts
@@ -8,8 +8,6 @@ import {
   GRANITE_VITEST_RN_CACHE_ENTRIES_DIRECTORY,
 } from './reactNative';
 
-vi.mock('@react-native/js-polyfills/error-guard', () => ({}));
-
 describe('reactNativeRuntime bootstrap', () => {
   let ReactNative: Record<string, any>;
   let RendererProxy: Record<string, any>;
@@ -18,18 +16,25 @@ describe('reactNativeRuntime bootstrap', () => {
     __GRANITE_VITEST_RN_CACHE_ROOT__?: string;
     IS_REACT_ACT_ENVIRONMENT?: boolean;
     IS_REACT_NATIVE_TEST_ENVIRONMENT?: boolean;
+    ErrorUtils?: Record<string, unknown>;
     nativeFabricUIManager?: Record<string, unknown>;
     window?: typeof globalThis;
   };
   const originalMirrorRoot = runtimeGlobals.__GRANITE_VITEST_RN_CACHE_ROOT__;
+  const originalErrorUtils = runtimeGlobals.ErrorUtils;
 
   afterAll(() => {
     if (originalMirrorRoot == null) {
       delete runtimeGlobals.__GRANITE_VITEST_RN_CACHE_ROOT__;
-      return;
+    } else {
+      runtimeGlobals.__GRANITE_VITEST_RN_CACHE_ROOT__ = originalMirrorRoot;
     }
 
-    runtimeGlobals.__GRANITE_VITEST_RN_CACHE_ROOT__ = originalMirrorRoot;
+    if (originalErrorUtils == null) {
+      delete runtimeGlobals.ErrorUtils;
+    } else {
+      runtimeGlobals.ErrorUtils = originalErrorUtils;
+    }
   });
 
   it('fails fast when reactNative() did not configure the mirror cache root', async () => {
@@ -62,6 +67,16 @@ describe('reactNativeRuntime bootstrap', () => {
       expect(runtimeGlobals.performance.now).toEqual(expect.any(Function));
       expect(runtimeGlobals.requestAnimationFrame).toEqual(expect.any(Function));
       expect(runtimeGlobals.cancelAnimationFrame).toEqual(expect.any(Function));
+      expect(runtimeGlobals.ErrorUtils).toMatchObject({
+        applyWithGuard: expect.any(Function),
+        applyWithGuardIfNeeded: expect.any(Function),
+        getGlobalHandler: expect.any(Function),
+        guard: expect.any(Function),
+        inGuard: expect.any(Function),
+        reportError: expect.any(Function),
+        reportFatalError: expect.any(Function),
+        setGlobalHandler: expect.any(Function),
+      });
     });
 
     it('exposes a representative React Native facade for tests', () => {

--- a/packages/vitest/src/reactNativeRuntime.ts
+++ b/packages/vitest/src/reactNativeRuntime.ts
@@ -3,7 +3,6 @@
 import path from 'node:path';
 import Module, { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
-import '@react-native/js-polyfills/error-guard';
 import type { ReactNode } from 'react';
 import { vi } from 'vitest';
 import { REACT_NATIVE_ASSET_MODULE_ID_PATTERN } from './assets';
@@ -2813,6 +2812,8 @@ function patchReactNativeResolution() {
 
   runtimeGlobals.__rntlVitestRnResolverPatched__ = true;
 }
+
+runtimeRequire(path.join(reactNativeMirrorRoot, '@react-native', 'js-polyfills', 'error-guard.js'));
 
 // Yarn PnP: top-level ESM imports of `react-native` must resolve to the same
 // singleton facade that the CommonJS loader patch returns.

--- a/packages/vitest/tsdown.config.ts
+++ b/packages/vitest/tsdown.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   entry: ['src/index.ts', 'src/reactNativeRuntime.ts', 'src/setup.ts'],
   format: ['esm'],
   dts: true,
+  exports: true,
   fixedExtension: false,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6256,7 +6256,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@granite-js/vitest@workspace:packages/vitest"
   dependencies:
-    "@react-native/js-polyfills": "npm:0.84.0"
     "@types/node": "catalog:tools"
     "@types/react": "catalog:react-native"
     fast-flow-transform: "npm:0.0.3"


### PR DESCRIPTION
## What
- enable `tsdown`-managed exports in `@granite-js/vitest` so `package.json` no longer has to manually maintain the exports map
- simplify `packages/vitest/package.json` exports to match the generated output and drop manual `main` / `module` entries
- remove the direct `@react-native/js-polyfills` dependency from `@granite-js/vitest`
- keep React Native runtime bootstrap installing `ErrorUtils` by loading the transformed `@react-native/js-polyfills/error-guard.js` from the consumer's mirrored React Native cache
- add a runtime bootstrap spec that verifies `ErrorUtils` is installed
- add a patch changeset for `@granite-js/vitest`

<img width="592" height="614" alt="스크린샷 2026-04-23 오후 12 10 19" src="https://github.com/user-attachments/assets/97b081e6-b69e-4a39-ba60-3f4ad53744a8" />

## Why
- the manual exports map can drift from the actual `tsdown` build output
- `@react-native/js-polyfills` is already owned by the consumer's installed `react-native`, so `@granite-js/vitest` does not need to vendor it directly
- loading the transformed mirror artifact preserves the RN error bootstrap contract without requiring the raw Flow source