### PR TITLE
fix(mpack): detect parent workspace root

### DIFF
--- a/.changeset/mpack-monorepo-root.md
+++ b/.changeset/mpack-monorepo-root.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/mpack': patch
+---
+
+Fix monorepo root detection for nested workspace apps.

--- a/packages/mpack/src/metro/getMonorepoRoot.spec.ts
+++ b/packages/mpack/src/metro/getMonorepoRoot.spec.ts
@@ -1,69 +1,81 @@
+import fs from 'fs/promises';
+import os from 'os';
 import path from 'path';
-import { afterAll, beforeAll, describe, expect, it, MockInstance, vitest } from 'vitest';
-import { getMonorepoRoot } from './getMonorepoRoot';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function importGetMonorepoRoot() {
+  vi.resetModules();
+  vi.doMock('./pnpapi', () => ({ pnpapi: undefined }));
+
+  return (await import('./getMonorepoRoot')).getMonorepoRoot;
+}
+
+async function writePackageJson(dir: string, contents: object) {
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'package.json'), `${JSON.stringify(contents)}\n`);
+}
 
 describe('getMonorepoRoot', () => {
-  describe('워크스페이스 프로젝트가 아닌 경우', () => {
-    beforeAll(() => {
-      vitest.mock('./pnpapi', () => {
-        return {
-          pnpapi: undefined,
-        };
-      });
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'granite-monorepo-root-'));
+  });
+
+  afterEach(async () => {
+    vi.doUnmock('./pnpapi');
+    vi.resetModules();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns the base path when no workspace root exists', async () => {
+    const getMonorepoRoot = await importGetMonorepoRoot();
+    const appPath = path.join(tempDir, 'app');
+
+    await writePackageJson(appPath, { name: 'app' });
+
+    await expect(getMonorepoRoot(appPath)).resolves.toBe(appPath);
+  });
+
+  it('returns the parent npm or Yarn workspace root', async () => {
+    const getMonorepoRoot = await importGetMonorepoRoot();
+    const workspaceRoot = path.join(tempDir, 'workspace');
+    const appPath = path.join(workspaceRoot, 'apps', 'app');
+
+    await writePackageJson(workspaceRoot, {
+      name: 'workspace',
+      workspaces: ['apps/*'],
     });
+    await writePackageJson(appPath, { name: 'app' });
 
-    describe('posix', () => {
-      let dirnameSpy: MockInstance;
+    await expect(getMonorepoRoot(appPath)).resolves.toBe(workspaceRoot);
+  });
 
-      beforeAll(() => {
-        dirnameSpy = vitest.spyOn(path, 'dirname');
-        vitest.mock('path', async () => {
-          const path = await vitest.importActual('path');
+  it('returns the parent pnpm workspace root', async () => {
+    const getMonorepoRoot = await importGetMonorepoRoot();
+    const workspaceRoot = path.join(tempDir, 'workspace');
+    const appPath = path.join(workspaceRoot, 'apps', 'app');
 
-          return { ...path, default: path.posix };
-        });
-      });
+    await writePackageJson(workspaceRoot, { name: 'workspace' });
+    await fs.writeFile(path.join(workspaceRoot, 'pnpm-workspace.yaml'), 'packages:\n  - apps/*\n');
+    await writePackageJson(appPath, { name: 'app' });
 
-      afterAll(() => {
-        vitest.restoreAllMocks();
-      });
+    await expect(getMonorepoRoot(appPath)).resolves.toBe(workspaceRoot);
+  });
 
-      it('루트 경로까지 탐색한뒤 기존 경로를 반환한다', async () => {
-        const root = await getMonorepoRoot('/foo/bar/baz/my-project');
-        expect(root).toBe('/foo/bar/baz/my-project');
-        expect(dirnameSpy).toBeCalledWith('/foo/bar/baz/my-project');
-        expect(dirnameSpy).toBeCalledWith('/foo/bar/baz');
-        expect(dirnameSpy).toBeCalledWith('/foo/bar');
-        expect(dirnameSpy).toBeCalledWith('/foo');
-        expect(dirnameSpy).toBeCalledWith('/');
-      });
-    });
+  it('uses the Plug-and-Play top-level package location when PnP is available', async () => {
+    const workspaceRoot = path.join(tempDir, 'pnp-workspace');
 
-    describe('windows', () => {
-      let dirnameSpy: MockInstance;
+    vi.resetModules();
+    vi.doMock('./pnpapi', () => ({
+      pnpapi: {
+        topLevel: {},
+        getPackageInformation: () => ({ packageLocation: workspaceRoot }),
+      },
+    }));
 
-      beforeAll(() => {
-        dirnameSpy = vitest.spyOn(path, 'dirname');
-        vitest.mock('path', async () => {
-          const path = await vitest.importActual('path');
+    const { getMonorepoRoot } = await import('./getMonorepoRoot');
 
-          return { ...path, default: path.win32 };
-        });
-      });
-
-      afterAll(() => {
-        vitest.restoreAllMocks();
-      });
-
-      it('루트 경로까지 탐색한뒤 기존 경로를 반환한다', async () => {
-        const root = await getMonorepoRoot('C:\\foo\\bar\\baz\\my-project');
-        expect(root).toBe('C:\\foo\\bar\\baz\\my-project');
-        expect(dirnameSpy).toBeCalledWith('C:\\foo\\bar\\baz\\my-project');
-        expect(dirnameSpy).toBeCalledWith('C:\\foo\\bar\\baz');
-        expect(dirnameSpy).toBeCalledWith('C:\\foo\\bar');
-        expect(dirnameSpy).toBeCalledWith('C:\\foo');
-        expect(dirnameSpy).toBeCalledWith('C:\\');
-      });
-    });
+    await expect(getMonorepoRoot(path.join(workspaceRoot, 'packages', 'app'))).resolves.toBe(workspaceRoot);
   });
 });

--- a/packages/mpack/src/metro/getMonorepoRoot.spec.ts
+++ b/packages/mpack/src/metro/getMonorepoRoot.spec.ts
@@ -37,6 +37,18 @@ describe('getMonorepoRoot', () => {
     await expect(getMonorepoRoot(appPath)).resolves.toBe(appPath);
   });
 
+  it('returns the base path itself when it is the workspace root', async () => {
+    const getMonorepoRoot = await importGetMonorepoRoot();
+    const workspaceRoot = path.join(tempDir, 'workspace');
+
+    await writePackageJson(workspaceRoot, {
+      name: 'workspace',
+      workspaces: ['apps/*'],
+    });
+
+    await expect(getMonorepoRoot(workspaceRoot)).resolves.toBe(workspaceRoot);
+  });
+
   it('returns the parent npm or Yarn workspace root', async () => {
     const getMonorepoRoot = await importGetMonorepoRoot();
     const workspaceRoot = path.join(tempDir, 'workspace');

--- a/packages/mpack/src/metro/getMonorepoRoot.ts
+++ b/packages/mpack/src/metro/getMonorepoRoot.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { pnpapi } from './pnpapi';
 
 /**
- * 단일 혹은 워크스페이스 기반 프로젝트 환경에서 적절한 루트 경로를 가져오는 유틸입니다
+ * Returns the appropriate root path for either a single-package project or a workspace-based project.
  */
 export async function getMonorepoRoot(basePath: string) {
   if (pnpapi) {
@@ -12,15 +12,14 @@ export async function getMonorepoRoot(basePath: string) {
 
   let curr = basePath;
   while (curr !== path.dirname(curr)) {
-    if (await isWorkspace(basePath)) {
+    if (await isWorkspace(curr)) {
       return curr;
     }
 
     curr = path.dirname(curr);
   }
 
-  // 루트 경로까지 탐색해도 workspaces 필드를 가진 `package.json` 파일이 없는 경우,
-  // 워크스페이스 프로젝트가 아닌 단일 프로젝트로 간주하여 기준 경로를 그대로 반환
+  // If no workspace root is found up to the filesystem root, treat it as a single-package project.
   return basePath;
 }
 
@@ -46,7 +45,7 @@ async function isWorkspace(basePath: string) {
   const hasPackageJson = Boolean(packageJson);
   const hasWorkspacesField = Array.isArray(packageJson?.workspaces);
 
-  // NPM, Yarn
+  // npm, Yarn
   if (hasWorkspacesField) {
     return true;
   }

--- a/packages/mpack/src/metro/getMonorepoRoot.ts
+++ b/packages/mpack/src/metro/getMonorepoRoot.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { pnpapi } from './pnpapi';
 
 /**
- * Returns the appropriate root path for either a single-package project or a workspace-based project.
+ * 단일 혹은 워크스페이스 기반 프로젝트 환경에서 적절한 루트 경로를 가져오는 유틸입니다
  */
 export async function getMonorepoRoot(basePath: string) {
   if (pnpapi) {
@@ -19,7 +19,8 @@ export async function getMonorepoRoot(basePath: string) {
     curr = path.dirname(curr);
   }
 
-  // If no workspace root is found up to the filesystem root, treat it as a single-package project.
+  // 루트 경로까지 탐색해도 workspaces 필드를 가진 `package.json` 파일이 없는 경우,
+  // 워크스페이스 프로젝트가 아닌 단일 프로젝트로 간주하여 기준 경로를 그대로 반환
   return basePath;
 }
 
@@ -45,7 +46,7 @@ async function isWorkspace(basePath: string) {
   const hasPackageJson = Boolean(packageJson);
   const hasWorkspacesField = Array.isArray(packageJson?.workspaces);
 
-  // npm, Yarn
+  // NPM, Yarn
   if (hasWorkspacesField) {
     return true;
   }


### PR DESCRIPTION
## Summary

This updates `getMonorepoRoot()` so it checks each directory while walking up from the app path.

Previously, the loop moved through parent directories with `curr`, but the workspace check still used the original `basePath`. For a nested app like `apps/mobile`, that meant a parent workspace root could be skipped and the app directory would be returned instead.

This also adds regression coverage for:

- a non-workspace project
- a base path that is itself the workspace root
- a parent npm/Yarn workspace
- a parent pnpm workspace
- the existing Plug-and-Play path

## Changes

- Check `isWorkspace(curr)` while walking up the directory tree.
- Keep the Plug-and-Play root detection path unchanged.
- Add a patch changeset for `@granite-js/mpack`.

## Validation

- `corepack yarn workspace @granite-js/mpack test:no-parallel src/metro/getMonorepoRoot.spec.ts`
- `corepack yarn workspace @granite-js/mpack typecheck`
- `corepack yarn eslint packages/mpack/src/metro/getMonorepoRoot.ts packages/mpack/src/metro/getMonorepoRoot.spec.ts`
- `corepack yarn prettier --check packages/mpack/src/metro/getMonorepoRoot.ts packages/mpack/src/metro/getMonorepoRoot.spec.ts .changeset/mpack-monorepo-root.md`