### PR TITLE
fix(forge-cli): await deployment tasks

### DIFF
--- a/.changeset/forge-cli-await-deploy.md
+++ b/.changeset/forge-cli-await-deploy.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/forge-cli': patch
+---
+
+Await bundle uploads before updating deployment state.

--- a/infra/forge-cli/src/operations/deploy.spec.ts
+++ b/infra/forge-cli/src/operations/deploy.spec.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deploy } from './deploy';
+
+type PromptTask = {
+  task: () => unknown | Promise<unknown>;
+};
+
+const promptMocks = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  intro: vi.fn(),
+  isCancel: vi.fn(),
+  log: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  outro: vi.fn(),
+  spinner: vi.fn(),
+  tasks: vi.fn(),
+}));
+
+const deploymentMocks = vi.hoisted(() => {
+  class NoSuchKey extends Error {}
+
+  return {
+    DeployManager: {
+      planRollout: vi.fn(),
+      readDeploymentState: vi.fn(),
+      rollout: vi.fn(),
+      updateBundleList: vi.fn(),
+      uploadBundle: vi.fn(),
+    },
+    NoSuchKey,
+  };
+});
+
+const utilityMocks = vi.hoisted(() => ({
+  generateDeploymentId: vi.fn(),
+  gzipFile: vi.fn(),
+}));
+
+vi.mock('@clack/prompts', () => promptMocks);
+vi.mock('@granite-js/deployment-manager', () => ({
+  ...deploymentMocks,
+  DeploymentState: undefined,
+}));
+vi.mock('../utils/generateDeploymentId', () => ({
+  generateDeploymentId: utilityMocks.generateDeploymentId,
+}));
+vi.mock('../utils/gzip', () => ({
+  gzipFile: utilityMocks.gzipFile,
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+async function flushPromises() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function waitFor(assertion: () => void) {
+  let lastError: unknown;
+
+  for (let i = 0; i < 50; i++) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flushPromises();
+    }
+  }
+
+  throw lastError;
+}
+
+const deployConfig = {
+  androidBundle: 'bundle.android.hbc',
+  appName: 'test-app',
+  iosBundle: 'bundle.ios.hbc',
+};
+
+const deployContext = {
+  s3Client: {} as never,
+};
+
+describe('deploy operation', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+
+    promptMocks.confirm.mockResolvedValue(true);
+    promptMocks.isCancel.mockReturnValue(false);
+    promptMocks.spinner.mockReturnValue({
+      start: vi.fn(),
+      stop: vi.fn(),
+    });
+    promptMocks.tasks.mockImplementation(async (tasks: PromptTask[]) => {
+      return Promise.all(tasks.map((task) => task.task()));
+    });
+
+    deploymentMocks.DeployManager.readDeploymentState.mockResolvedValue(null);
+    deploymentMocks.DeployManager.planRollout.mockResolvedValue({
+      deploymentId: 'deployment-id',
+      type: 'STABLE',
+    });
+    deploymentMocks.DeployManager.updateBundleList.mockResolvedValue(undefined);
+    deploymentMocks.DeployManager.rollout.mockResolvedValue(undefined);
+
+    utilityMocks.generateDeploymentId.mockReturnValue('deployment-id');
+    utilityMocks.gzipFile.mockResolvedValue(undefined);
+  });
+
+  it('does not update bundle list or rollout before both uploads resolve', async () => {
+    const androidUpload = createDeferred<void>();
+    const iosUpload = createDeferred<void>();
+
+    deploymentMocks.DeployManager.uploadBundle.mockImplementation(
+      ({ platform }: { platform: 'android' | 'ios' }) => {
+        if (platform === 'android') {
+          return androidUpload.promise;
+        }
+        if (platform === 'ios') {
+          return iosUpload.promise;
+        }
+        throw new Error(`Unexpected platform: ${platform}`);
+      }
+    );
+
+    const deployPromise = deploy(deployConfig, deployContext);
+
+    await waitFor(() => {
+      expect(deploymentMocks.DeployManager.uploadBundle).toHaveBeenCalledTimes(2);
+    });
+
+    expect(deploymentMocks.DeployManager.updateBundleList).not.toHaveBeenCalled();
+    expect(deploymentMocks.DeployManager.rollout).not.toHaveBeenCalled();
+
+    androidUpload.resolve();
+    await flushPromises();
+
+    expect(deploymentMocks.DeployManager.updateBundleList).not.toHaveBeenCalled();
+    expect(deploymentMocks.DeployManager.rollout).not.toHaveBeenCalled();
+
+    iosUpload.resolve();
+
+    await deployPromise;
+
+    expect(deploymentMocks.DeployManager.updateBundleList).toHaveBeenCalledTimes(1);
+    expect(deploymentMocks.DeployManager.rollout).toHaveBeenCalledTimes(1);
+
+    const updateOrder = deploymentMocks.DeployManager.updateBundleList.mock.invocationCallOrder[0];
+    const rolloutOrder = deploymentMocks.DeployManager.rollout.mock.invocationCallOrder[0];
+
+    expect(updateOrder).toBeDefined();
+    expect(rolloutOrder).toBeDefined();
+    expect(updateOrder!).toBeLessThan(rolloutOrder!);
+  });
+
+  it('prevents bundle list update and rollout when an upload rejects', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit:${code}`);
+    });
+    const androidUpload = createDeferred<void>();
+    const iosUpload = createDeferred<void>();
+
+    androidUpload.promise.catch(() => undefined);
+    deploymentMocks.DeployManager.uploadBundle.mockImplementation(
+      ({ platform }: { platform: 'android' | 'ios' }) => {
+        if (platform === 'android') {
+          return androidUpload.promise;
+        }
+        if (platform === 'ios') {
+          return iosUpload.promise;
+        }
+        throw new Error(`Unexpected platform: ${platform}`);
+      }
+    );
+
+    const deployPromise = deploy(deployConfig, deployContext);
+
+    await waitFor(() => {
+      expect(deploymentMocks.DeployManager.uploadBundle).toHaveBeenCalledTimes(2);
+    });
+
+    androidUpload.reject(new Error('upload failed'));
+    iosUpload.resolve();
+
+    await expect(deployPromise).rejects.toThrow('process.exit:1');
+
+    expect(promptMocks.log.error).toHaveBeenCalledWith('upload failed');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(deploymentMocks.DeployManager.updateBundleList).not.toHaveBeenCalled();
+    expect(deploymentMocks.DeployManager.rollout).not.toHaveBeenCalled();
+  });
+});

--- a/infra/forge-cli/src/operations/deploy.ts
+++ b/infra/forge-cli/src/operations/deploy.ts
@@ -12,9 +12,7 @@ interface DeployConfig {
   groupId?: string;
 }
 
-export const deploy = handlePrompts<
-  ({ androidBundle, iosBundle, appName, tag }: DeployConfig, context: { s3Client: S3Client }) => void
->('Start deployment', deployImpl);
+export const deploy = handlePrompts('Start deployment', deployImpl);
 
 async function deployImpl({ androidBundle, iosBundle, appName, tag }: DeployConfig, context: { s3Client: S3Client }) {
   const { s3Client } = context;
@@ -78,7 +76,7 @@ async function deployImpl({ androidBundle, iosBundle, appName, tag }: DeployConf
     ].map(({ bundlePath, platform }) => ({
       title: `Uploading bundle... (${platform})`,
       task: async () => {
-        DeployManager.uploadBundle(
+        await DeployManager.uploadBundle(
           {
             bundlePath,
             appName,

--- a/infra/forge-cli/src/utils/handlePrompts.spec.ts
+++ b/infra/forge-cli/src/utils/handlePrompts.spec.ts
@@ -1,0 +1,73 @@
+import * as p from '@clack/prompts';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { handlePrompts } from './handlePrompts';
+
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  log: {
+    error: vi.fn(),
+  },
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+async function flushPromises() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('handlePrompts', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('keeps the wrapper pending until an async task resolves', async () => {
+    const deferred = createDeferred<string>();
+    const wrapped = handlePrompts('Async task', () => deferred.promise);
+
+    const result = wrapped();
+    let settled = false;
+    void result.then(() => {
+      settled = true;
+    });
+
+    await flushPromises();
+
+    expect(p.intro).toHaveBeenCalledWith('Async task');
+    expect(settled).toBe(false);
+
+    deferred.resolve('done');
+
+    await expect(result).resolves.toBe('done');
+    expect(settled).toBe(true);
+  });
+
+  it('normalizes a synchronous task return to an awaitable result', async () => {
+    const wrapped = handlePrompts('Sync task', (left: number, right: number) => left + right);
+
+    await expect(wrapped(2, 3)).resolves.toBe(5);
+  });
+
+  it('routes async rejection through the prompt error handler', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit:${code}`);
+    });
+    const wrapped = handlePrompts('Rejecting task', async () => {
+      throw new Error('task failed');
+    });
+
+    await expect(wrapped()).rejects.toThrow('process.exit:1');
+
+    expect(p.log.error).toHaveBeenCalledWith('task failed');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/infra/forge-cli/src/utils/handlePrompts.ts
+++ b/infra/forge-cli/src/utils/handlePrompts.ts
@@ -1,22 +1,23 @@
 import * as p from '@clack/prompts';
 
-export function handlePrompts<T extends (...args: any[]) => any>(title: string, task: T) {
-  return (...args: Parameters<T>) => {
+type Task = (...args: any[]) => unknown;
+
+export function handlePrompts<T extends Task>(
+  title: string,
+  task: T
+): (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>> {
+  return async (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
     p.intro(title);
 
     try {
-      const result = task.call(null, ...args);
-
-      if (result instanceof Promise) {
-        result.catch(promptErrorHandler);
-      }
+      return (await task.call(null, ...args)) as Awaited<ReturnType<T>>;
     } catch (error) {
       promptErrorHandler(error);
     }
   };
 }
 
-function promptErrorHandler(error: unknown) {
+function promptErrorHandler(error: unknown): never {
   p.log.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

- make `handlePrompts` return an awaitable wrapper result instead of starting async tasks without returning them
- await `DeployManager.uploadBundle` inside Forge deploy upload tasks before continuing to bundle-list update and rollout
- add focused tests for prompt wrapper async/error behavior and deployment upload sequencing

## Test plan

- `yarn workspace @granite-js/forge-cli test`
- `yarn workspace @granite-js/forge-cli typecheck`
- `yarn workspace @granite-js/forge-cli build`
