### PR TITLE
feat: propagate esbuild resolve result options in alias resolver

### DIFF
--- a/.changeset/purple-rings-shake.md
+++ b/.changeset/purple-rings-shake.md
@@ -1,0 +1,6 @@
+---
+'@granite-js/plugin-core': patch
+'@granite-js/mpack': patch
+---
+
+propagate esbuild resolve result options in alias resolver

--- a/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/entry.ts
+++ b/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/entry.ts
@@ -1,0 +1,3 @@
+import { foo } from './foo';
+
+console.log('entry', foo);

--- a/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/foo.d.ts
+++ b/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/foo.d.ts
@@ -1,0 +1,1 @@
+export const foo: string;

--- a/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/packages/foo/bar-cjs.cjs
+++ b/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/packages/foo/bar-cjs.cjs
@@ -1,0 +1,1 @@
+exports.bar = 'bar';

--- a/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/packages/foo/bar-esm.ts
+++ b/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/packages/foo/bar-esm.ts
@@ -1,0 +1,1 @@
+export const bar = 'bar';

--- a/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/packages/foo/cjs.cjs
+++ b/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/packages/foo/cjs.cjs
@@ -1,0 +1,3 @@
+const { bar } = require('./bar-cjs.cjs');
+
+exports.foo = `cjs ${bar}`;

--- a/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/packages/foo/esm.ts
+++ b/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/fixtures/resolver-results/packages/foo/esm.ts
@@ -1,0 +1,3 @@
+import { bar } from './bar-esm';
+
+export const foo = `esm ${bar}`;

--- a/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/resolvePlugin.spec.ts
+++ b/packages/mpack/src/bundler/plugins/resolvePlugin/__tests__/resolvePlugin.spec.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import type { BuildConfig } from '@granite-js/plugin-core';
+import type { ImportKind, Plugin } from 'esbuild';
 import { describe, expect, it } from 'vitest';
 import { buildWithEsbuild, evaluate } from '../../../../testing';
 import type { INTERNAL__Id } from '../../../../types';
@@ -18,7 +19,7 @@ describe('resolvePlugin', () => {
           },
         };
 
-        const code = await buildWithEsbuild(buildConfig, {
+        const result = await buildWithEsbuild(buildConfig, {
           plugins: [
             resolvePlugin({
               context: {
@@ -35,7 +36,7 @@ describe('resolvePlugin', () => {
           ],
         });
 
-        expect(await evaluate(code)).toContain('foo 2');
+        expect(await evaluate(result.code)).toContain('foo 2');
       });
 
       it('should resolve alias 2 (object)', async () => {
@@ -55,7 +56,7 @@ describe('resolvePlugin', () => {
           },
         };
 
-        const code = await buildWithEsbuild(buildConfig, {
+        const result = await buildWithEsbuild(buildConfig, {
           plugins: [
             resolvePlugin({
               context: {
@@ -72,7 +73,129 @@ describe('resolvePlugin', () => {
           ],
         });
 
-        expect(await evaluate(code)).toContain('foo 2');
+        expect(await evaluate(result.code)).toContain('foo 2');
+      });
+
+      it('should pass esbuild resolve kind to the bundled metafile', async () => {
+        const kindSensitivePath = 'kind-sensitive-foo';
+        let observedKind: ImportKind | undefined;
+        const buildConfig: BuildConfig = {
+          entry: path.resolve(__dirname, 'fixtures/resolver-results/entry.ts'),
+          outfile: '',
+          platform: 'android',
+          resolver: {
+            alias: [
+              {
+                from: './foo',
+                to: {
+                  // 'foo' is written by TypeScript, so default kind is 'import-statement'.
+                  path: kindSensitivePath,
+                  kind: 'require-call',
+                },
+              },
+            ],
+          },
+        };
+        const kindSensitiveResolver: Plugin = {
+          name: 'kind-sensitive-fixture-resolver',
+          setup(build) {
+            build.onResolve({ filter: new RegExp(`^${kindSensitivePath}$`) }, (args) => {
+              observedKind = args.kind;
+
+              return {
+                path: path.resolve(
+                  __dirname,
+                  args.kind === 'require-call'
+                    ? 'fixtures/resolver-results/packages/foo/cjs.cjs'
+                    : 'fixtures/resolver-results/packages/foo/esm.ts'
+                ),
+              };
+            });
+          },
+        };
+
+        const result = await buildWithEsbuild(buildConfig, {
+          format: 'cjs',
+          metafile: true,
+          platform: 'node',
+          plugins: [
+            resolvePlugin({
+              context: {
+                id: 'id' as INTERNAL__Id,
+                config: {
+                  cache: false,
+                  dev: false,
+                  metafile: true,
+                  rootDir: __dirname,
+                  buildConfig,
+                },
+              },
+            }),
+            kindSensitiveResolver,
+          ],
+        });
+
+        const inputPaths = Object.keys(result.metafile?.inputs ?? {});
+        const fooInput = Object.entries(result.metafile?.inputs ?? {}).find(([inputPath]) =>
+          inputPath.endsWith('fixtures/resolver-results/packages/foo/cjs.cjs')
+        )?.[1];
+        const barImport = fooInput?.imports.find((imported) =>
+          imported.path.endsWith('fixtures/resolver-results/packages/foo/bar-cjs.cjs')
+        );
+        const hasEsmFooInput = inputPaths.some((inputPath) =>
+          inputPath.endsWith('fixtures/resolver-results/packages/foo/esm.ts')
+        );
+
+        expect(observedKind).toBe('require-call');
+        expect(hasEsmFooInput).toBe(false);
+        expect(await evaluate(result.code)).toContain('entry cjs bar');
+        expect(fooInput?.format).toBe('cjs');
+        expect(barImport?.kind).toBe('require-call');
+      });
+
+      it('should pass esbuild onResolve result options to the bundle', async () => {
+        const buildConfig: BuildConfig = {
+          entry: path.resolve(__dirname, 'fixtures/deps-alias/entry.ts'),
+          outfile: '',
+          platform: 'android',
+          resolver: {
+            alias: [
+              {
+                from: './foo',
+                to: {
+                  path: './foo-2',
+                  external: true,
+                },
+              },
+            ],
+          },
+        };
+
+        const result = await buildWithEsbuild(buildConfig, {
+          format: 'cjs',
+          metafile: true,
+          platform: 'node',
+          plugins: [
+            resolvePlugin({
+              context: {
+                id: 'id' as INTERNAL__Id,
+                config: {
+                  cache: false,
+                  dev: false,
+                  metafile: true,
+                  rootDir: __dirname,
+                  buildConfig,
+                },
+              },
+            }),
+          ],
+        });
+
+        const inputPaths = Object.keys(result.metafile?.inputs ?? {});
+        const outputImports = Object.values(result.metafile?.outputs ?? {}).flatMap((output) => output.imports);
+
+        expect(inputPaths.some((inputPath) => inputPath.endsWith('fixtures/deps-alias/foo-2.ts'))).toBe(false);
+        expect(outputImports).toContainEqual(expect.objectContaining({ external: true }));
       });
     });
 
@@ -101,7 +224,7 @@ describe('resolvePlugin', () => {
           },
         };
 
-        const code = await buildWithEsbuild(buildConfig, {
+        const result = await buildWithEsbuild(buildConfig, {
           plugins: [
             resolvePlugin({
               context: {
@@ -118,7 +241,7 @@ describe('resolvePlugin', () => {
           ],
         });
 
-        expect(await evaluate(code)).toContain('foo 2');
+        expect(await evaluate(result.code)).toContain('foo 2');
       });
 
       it('should resolve alias 2 (object)', async () => {
@@ -143,7 +266,7 @@ describe('resolvePlugin', () => {
           },
         };
 
-        const code = await buildWithEsbuild(buildConfig, {
+        const result = await buildWithEsbuild(buildConfig, {
           plugins: [
             resolvePlugin({
               context: {
@@ -160,7 +283,7 @@ describe('resolvePlugin', () => {
           ],
         });
 
-        expect(await evaluate(code)).toContain('foo 2');
+        expect(await evaluate(result.code)).toContain('foo 2');
       });
     });
   });
@@ -186,7 +309,7 @@ describe('resolvePlugin', () => {
         },
       };
 
-      const code = await buildWithEsbuild(buildConfig, {
+      const result = await buildWithEsbuild(buildConfig, {
         plugins: [
           resolvePlugin({
             context: {
@@ -203,7 +326,7 @@ describe('resolvePlugin', () => {
         ],
       });
 
-      expect(await evaluate(code)).toContain('Module source is my-module');
+      expect(await evaluate(result.code)).toContain('Module source is my-module');
     });
   });
 });

--- a/packages/mpack/src/bundler/plugins/resolvePlugin/alias/setupAliasResolver.ts
+++ b/packages/mpack/src/bundler/plugins/resolvePlugin/alias/setupAliasResolver.ts
@@ -1,7 +1,7 @@
 import path from 'path';
-import type { AliasConfig, ResolveResult } from '@granite-js/plugin-core';
+import type { AliasConfig, ResolveResult, ResolveResultWithOptions } from '@granite-js/plugin-core';
 import { assert } from 'es-toolkit';
-import type { OnResolveArgs, PluginBuild, ResolveOptions } from 'esbuild';
+import type { OnResolveArgs, OnResolveResult, PluginBuild, ResolveOptions } from 'esbuild';
 import { Performance } from '../../../../performance';
 import { normalizePath } from '../../../../utils/esbuildUtils';
 import { replaceModulePath } from '../../../../utils/replaceModulePath';
@@ -12,7 +12,7 @@ export function setupAliasResolver(build: PluginBuild, aliasConfig: AliasConfig[
   const resolver = createNonRecursiveResolver(build);
 
   [swcHelperOptimizationRules.getAliasConfig(), ...aliasConfig].forEach((aliasConfig) => {
-    const resolveResultCache = new Map<string, { path: string }>();
+    const resolveResultCache = new Map<string, OnResolveResult>();
     const { filter, resolveAlias } = resolveAliasConfig(build, aliasConfig);
 
     build.onResolve({ filter }, async (args) => {
@@ -24,16 +24,9 @@ export function setupAliasResolver(build: PluginBuild, aliasConfig: AliasConfig[
         detail: { pattern: filter, path: args.path },
       });
 
-      const defaultResolveOptions = {
-        resolveDir: args.resolveDir,
-        importer: args.importer,
-        kind: args.kind,
-        with: args.with,
-      };
-
       const resolveResult = await resolveAlias(args);
       const resolvePath = resolveResult.path;
-      const resolveOptions = { ...defaultResolveOptions, ...(resolveResult.options ?? {}) };
+      const resolveOptions = toResolveOptions(args, resolveResult);
 
       const cacheKey = `${resolveOptions.kind}:${resolveOptions.resolveDir}:${resolvePath}`;
 
@@ -44,17 +37,27 @@ export function setupAliasResolver(build: PluginBuild, aliasConfig: AliasConfig[
 
       if (path.isAbsolute(resolvePath)) {
         trace.stop({ detail: { isAbsolute: true } });
-        const result = { path: resolvePath };
+        const result: OnResolveResult = { path: resolvePath };
+        applyOnResolveResultOptions(result, resolveResult);
         resolveResultCache.set(cacheKey, result);
         return result;
       }
 
-      const pathOverriddenArgs = { ...args, path: resolvePath };
+      const pathOverriddenArgs: OnResolveArgs = {
+        path: resolvePath,
+        importer: args.importer,
+        namespace: args.namespace,
+        resolveDir: args.resolveDir,
+        kind: args.kind,
+        pluginData: args.pluginData,
+        with: args.with,
+      };
       const result = await resolver(pathOverriddenArgs, resolveOptions);
 
       if (result) {
         trace.stop({ detail: { cacheHit: false, isAbsolute: false } });
 
+        applyOnResolveResultOptions(result, resolveResult);
         resolveResultCache.set(cacheKey, result);
 
         return result;
@@ -71,8 +74,19 @@ function resolveAliasConfig(build: PluginBuild, aliasConfig: AliasConfig) {
   const filter = new RegExp(exact ? `^${escapedFrom}$` : `^${escapedFrom}(?:$|/)`);
   const resolver = createNonRecursiveResolver(build);
 
-  const aliasResolver = (boundArgs: OnResolveArgs, path: string, options: ResolveOptions) => {
-    const result = resolver({ ...boundArgs, path }, options);
+  const aliasResolver = (args: OnResolveArgs, path: string, options: ResolveOptions) => {
+    const result = resolver(
+      {
+        path,
+        importer: args.importer,
+        namespace: args.namespace,
+        resolveDir: args.resolveDir,
+        kind: args.kind,
+        pluginData: args.pluginData,
+        with: args.with,
+      },
+      options
+    );
     assert(result, 'resolver should return result');
     return result;
   };
@@ -97,11 +111,61 @@ function escapeRegExpString(str: string) {
   return str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
 }
 
-function normalizeResolveResult(result: ResolveResult) {
+function normalizeResolveResult(result: ResolveResult): ResolveResultWithOptions {
   if (typeof result === 'string') {
-    return { path: normalizePath(result), options: undefined };
+    return { path: normalizePath(result) };
   }
 
-  const { path, ...options } = result;
-  return { path, options };
+  return result;
+}
+
+function toResolveOptions(args: OnResolveArgs, result: ResolveResultWithOptions): ResolveOptions {
+  return {
+    resolveDir: result.resolveDir ?? args.resolveDir,
+    importer: result.importer ?? args.importer,
+    kind: result.kind ?? args.kind,
+    with: result.with ?? args.with,
+  };
+}
+
+function applyOnResolveResultOptions(target: OnResolveResult, source: OnResolveResult) {
+  if (source.pluginName !== undefined) {
+    target.pluginName = source.pluginName;
+  }
+
+  if (source.errors !== undefined) {
+    target.errors = source.errors;
+  }
+
+  if (source.warnings !== undefined) {
+    target.warnings = source.warnings;
+  }
+
+  if (source.external !== undefined) {
+    target.external = source.external;
+  }
+
+  if (source.sideEffects !== undefined) {
+    target.sideEffects = source.sideEffects;
+  }
+
+  if (source.namespace !== undefined) {
+    target.namespace = source.namespace;
+  }
+
+  if (source.suffix !== undefined) {
+    target.suffix = source.suffix;
+  }
+
+  if (source.pluginData !== undefined) {
+    target.pluginData = source.pluginData;
+  }
+
+  if (source.watchFiles !== undefined) {
+    target.watchFiles = source.watchFiles;
+  }
+
+  if (source.watchDirs !== undefined) {
+    target.watchDirs = source.watchDirs;
+  }
 }

--- a/packages/mpack/src/bundler/plugins/transformPlugin/__tests__/transformPlugin.spec.ts
+++ b/packages/mpack/src/bundler/plugins/transformPlugin/__tests__/transformPlugin.spec.ts
@@ -16,7 +16,7 @@ describe('transformPlugin', () => {
       },
     };
 
-    const code = await buildWithEsbuild(buildConfig, {
+    const result = await buildWithEsbuild(buildConfig, {
       plugins: [
         transformPlugin({
           context: {
@@ -33,6 +33,6 @@ describe('transformPlugin', () => {
       ],
     });
 
-    expect(await evaluate(code)).toContain('passed');
+    expect(await evaluate(result.code)).toContain('passed');
   });
 });

--- a/packages/mpack/src/testing/buildWithEsbuild.ts
+++ b/packages/mpack/src/testing/buildWithEsbuild.ts
@@ -3,7 +3,14 @@ import type { BuildConfig } from '@granite-js/plugin-core';
 import { omit, toMerged } from 'es-toolkit';
 import * as esbuild from 'esbuild';
 
-export async function buildWithEsbuild(buildConfig: BuildConfig, options?: esbuild.BuildOptions) {
+export type BuildWithEsbuildResult = esbuild.BuildResult & {
+  readonly code: string;
+};
+
+export async function buildWithEsbuild(
+  buildConfig: BuildConfig,
+  options?: esbuild.BuildOptions
+): Promise<BuildWithEsbuildResult> {
   let esbuildOptions = options;
 
   if (buildConfig?.esbuild) {
@@ -17,9 +24,17 @@ export async function buildWithEsbuild(buildConfig: BuildConfig, options?: esbui
     write: false,
   });
 
-  const output = result.outputFiles?.[0]?.contents;
+  let code: string | undefined;
 
-  assert(output, 'output contents is empty');
+  Object.defineProperty(result, 'code', {
+    get() {
+      const output = result.outputFiles?.[0]?.contents;
+      assert(output, 'output contents is empty');
 
-  return Buffer.from(output).toString();
+      code ??= Buffer.from(output).toString();
+      return code;
+    },
+  });
+
+  return result as BuildWithEsbuildResult;
 }

--- a/packages/plugin-core/src/types/BuildConfig.ts
+++ b/packages/plugin-core/src/types/BuildConfig.ts
@@ -123,7 +123,7 @@ export interface AliasConfig extends Pick<esbuild.ResolveOptions, 'importer' | '
 
 export type ResolveResult = string | ResolveResultWithOptions;
 
-export interface ResolveResultWithOptions extends Omit<esbuild.ResolveOptions, 'pluginName' | 'pluginData'> {
+export interface ResolveResultWithOptions extends esbuild.ResolveOptions, esbuild.OnResolveResult {
   path: string;
 }
 


### PR DESCRIPTION
# Description

Propagate esbuild resolve result options in alias resolver.

Forward alias `to` options to either `build.resolve` or final `onResolve` result by esbuild option type.

<img width="731" height="229" alt="image" src="https://github.com/user-attachments/assets/3ea71459-a288-4b27-824b-602573a1def4" />
