### PR TITLE
fix(plugin-router): preserve default watch option

### DIFF
--- a/.changeset/plugin-router-watch-default.md
+++ b/.changeset/plugin-router-watch-default.md
@@ -1,0 +1,5 @@
+---
+"@granite-js/plugin-router": patch
+---
+
+Preserve the default route file watcher when router options are empty.

--- a/packages/plugin-router/src/routerPlugin.spec.ts
+++ b/packages/plugin-router/src/routerPlugin.spec.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { router } from './routerPlugin';
+
+const mocks = vi.hoisted(() => ({
+  generateRouterFile: vi.fn(),
+  watchRouter: vi.fn(),
+}));
+
+vi.mock('./generateRouterFile', () => ({
+  generateRouterFile: mocks.generateRouterFile,
+}));
+
+vi.mock('./watchRouter', () => ({
+  watchRouter: mocks.watchRouter,
+}));
+
+describe('router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('watches route files by default when options are empty', () => {
+    const plugin = router({});
+
+    plugin.dev?.handler.call({ meta: {} }, {} as never);
+
+    expect(mocks.generateRouterFile).toHaveBeenCalledOnce();
+    expect(mocks.watchRouter).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/plugin-router/src/routerPlugin.ts
+++ b/packages/plugin-router/src/routerPlugin.ts
@@ -11,6 +11,8 @@ const DEFAULT_OPTIONS: Required<RouterPluginOptions> = {
 };
 
 export const router = (options: RouterPluginOptions = DEFAULT_OPTIONS): GranitePluginCore => {
+  const resolvedOptions = { ...DEFAULT_OPTIONS, ...options };
+
   return {
     name: 'router-plugin',
     build: {
@@ -23,7 +25,7 @@ export const router = (options: RouterPluginOptions = DEFAULT_OPTIONS): GraniteP
       order: 'pre',
       handler: () => {
         generateRouterFile();
-        if (options.watch) {
+        if (resolvedOptions.watch) {
           watchRouter();
         }
       },


### PR DESCRIPTION
## Summary

- preserve `watch: true` when `router({})` is called with an empty options object
- add a focused regression test for the plugin dev handler
- add a patch changeset for `@granite-js/plugin-router`

## Test plan

- `yarn workspace @granite-js/plugin-router test src/routerPlugin.spec.ts`
- `yarn workspace @granite-js/plugin-router test`
- `yarn workspace @granite-js/plugin-core build`
- `yarn workspace @granite-js/plugin-router typecheck`
- `yarn eslint packages/plugin-router/src/routerPlugin.ts packages/plugin-router/src/routerPlugin.spec.ts`
- `yarn workspace @granite-js/plugin-router build`
