### PR TITLE
fix: type inference failure for route params in `NavigationHelpersRoute`

### DIFF
--- a/packages/react-native/src/router/createRoute.ts
+++ b/packages/react-native/src/router/createRoute.ts
@@ -29,10 +29,16 @@ export interface RegisterScreenInput {}
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface RegisterScreen {}
 
-export type NavigationProps = NativeStackNavigationProp<
+type RegisteredParamList = keyof RegisterScreenInput extends never ? ParamListBase : RegisterScreenInput;
+
+type NavigationParamsHelpers = Pick<
   // @ts-expect-error - override type
-  keyof RegisterScreenInput extends never ? ParamListBase : RegisterScreenInput
+  NativeStackNavigationProp<RegisteredParamList, keyof RegisteredParamList>,
+  'replaceParams' | 'setParams'
 >;
+
+export type NavigationProps = Omit<NativeStackNavigationProp<ParamListBase>, keyof NavigationParamsHelpers> &
+  NavigationParamsHelpers;
 
 export function useNavigation() {
   return useNavigationNative<NavigationProps>();

--- a/services/showcase/pages/showcase/image.tsx
+++ b/services/showcase/pages/showcase/image.tsx
@@ -2,13 +2,16 @@ import { createRoute, Image } from '@granite-js/react-native';
 import { View } from 'react-native';
 
 export const Route = createRoute('/showcase/image', {
-  validateParams: (params) => params,
+  validateParams: (params) => params as { uri?: string },
   component: ShowcaseImage,
 });
 
 function ShowcaseImage() {
+  const params = Route.useParams();
+
   return (
     <View>
+      {params.uri ? <Image source={{ uri: params.uri }} style={{ width: 100, height: 100 }} /> : null}
       <Image
         style={{ width: 100, height: 100 }}
         source={{ uri: 'https://picsum.photos/200' }}


### PR DESCRIPTION
# Description

Fix type inference failure for route params in NavigationHelpersRoute

| Before | After |
|:---:|:---:|
| <img width="752" height="120" alt="스크린샷 2026-05-14 오후 6 33 47" src="https://github.com/user-attachments/assets/ddeebef4-b7e4-4869-b0c0-0edeaf592c97" /> Always `Partial<unknown>` | <img width="756" height="160" alt="스크린샷 2026-05-14 오후 6 35 02" src="https://github.com/user-attachments/assets/43b15b76-6cc6-40d6-98c3-319278c7383e" /> Fixed |