### PR TITLE
fix: GraniteImage layout on reused cells

### DIFF
--- a/.changeset/fresh-rings-bake.md
+++ b/.changeset/fresh-rings-bake.md
@@ -1,0 +1,5 @@
+---
+"@granite-js/image": patch
+---
+
+Fix Android GraniteImage rendering when the native provider view is replaced after the parent view is already laid out.

--- a/packages/image/android/src/main/java/run/granite/image/GraniteImage.kt
+++ b/packages/image/android/src/main/java/run/granite/image/GraniteImage.kt
@@ -130,11 +130,7 @@ class GraniteImage(context: Context) : FrameLayout(context) {
     }
 
     private fun loadImageIfReady() {
-        // Remove existing container view
-        containerView?.let {
-            removeView(it)
-            containerView = null
-        }
+        clearContainerView()
 
         val provider = providerResolver()
 
@@ -154,15 +150,8 @@ class GraniteImage(context: Context) : FrameLayout(context) {
         // Emit load start event
         emitLoadStart()
 
-        // Create new image view from provider
         val imageView = provider.createImageView(context)
-        imageView.layoutParams = LayoutParams(
-            LayoutParams.MATCH_PARENT,
-            LayoutParams.MATCH_PARENT
-        )
-        addView(imageView)
-        containerView = imageView
-        layoutContainerViewIfPossible(imageView)
+        attachContainerView(imageView)
 
         // Load image using provider with full options
         provider.loadImage(
@@ -186,6 +175,23 @@ class GraniteImage(context: Context) : FrameLayout(context) {
         )
     }
 
+    private fun attachContainerView(view: View) {
+        view.layoutParams = LayoutParams(
+            LayoutParams.MATCH_PARENT,
+            LayoutParams.MATCH_PARENT
+        )
+        addView(view)
+        containerView = view
+        layoutContainerViewIfPossible(view)
+    }
+
+    private fun clearContainerView() {
+        containerView?.let {
+            removeView(it)
+            containerView = null
+        }
+    }
+
     private fun layoutContainerViewIfPossible(view: View) {
         if (width <= 0 || height <= 0) {
             return
@@ -195,6 +201,16 @@ class GraniteImage(context: Context) : FrameLayout(context) {
         val heightSpec = MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
         view.measure(widthSpec, heightSpec)
         view.layout(0, 0, width, height)
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        containerView?.let(::layoutContainerViewIfPossible)
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        containerView?.let(::layoutContainerViewIfPossible)
     }
 
     private fun handleLoadCompletion(
@@ -257,17 +273,15 @@ class GraniteImage(context: Context) : FrameLayout(context) {
         }
 
         errorView.addView(label)
-        addView(errorView)
-        containerView = errorView
+        attachContainerView(errorView)
     }
 
     fun cleanup() {
         val provider = providerResolver()
         containerView?.let {
             provider?.cancelLoad(it)
-            removeView(it)
         }
-        containerView = null
+        clearContainerView()
         currentUri = null
     }
 

--- a/packages/image/android/src/main/java/run/granite/image/GraniteImage.kt
+++ b/packages/image/android/src/main/java/run/granite/image/GraniteImage.kt
@@ -162,6 +162,7 @@ class GraniteImage(context: Context) : FrameLayout(context) {
         )
         addView(imageView)
         containerView = imageView
+        layoutContainerViewIfPossible(imageView)
 
         // Load image using provider with full options
         provider.loadImage(
@@ -183,6 +184,17 @@ class GraniteImage(context: Context) : FrameLayout(context) {
                 }
             }
         )
+    }
+
+    private fun layoutContainerViewIfPossible(view: View) {
+        if (width <= 0 || height <= 0) {
+            return
+        }
+
+        val widthSpec = MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY)
+        val heightSpec = MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+        view.measure(widthSpec, heightSpec)
+        view.layout(0, 0, width, height)
     }
 
     private fun handleLoadCompletion(


### PR DESCRIPTION
## Cause

Some images were not visible on virtualized list screens

The exact flow was:

1. FlashList/RN reuses a cell.
2. The outer `GraniteImage` already has a `498x498` layout area.
3. The `source` prop changes and `GraniteImage.loadImageIfReady()` runs.
4. The previous internal `ImageView` is removed with `removeView()`.
5. A new internal `ImageView` is added with `addView()`.
6. Coil successfully sets the bitmap on the new `ImageView`.
7. However, after the new `ImageView` is added, measure/layout does not run again, so it remains `0x0`.
8. As a result, only the parent/wrapper background is visible instead of the image.

In other words, during virtual list cell reuse, the outer `GraniteImage` managed by RN/Fabric had the correct size, but the newly replaced native child `ImageView` inside `GraniteImage` did not receive layout.

The diagnostic logs confirmed that Coil loading succeeded, but the internal `ImageView` still had a `0x0` size.

```text
event=coil_success ... size=0x0 measured=0x0 ... drawable=BitmapDrawable ... bitmap=600x600
```

## Fix

After adding the provider-created internal `ImageView`, this change immediately measures and lays it out to the current parent `GraniteImage` bounds when the parent already has a size.

```kotlin
addView(imageView)
containerView = imageView
layoutContainerViewIfPossible(imageView)
```

This ensures that when only the internal child View is replaced while the outer View is already laid out, the new `ImageView` does not stay at `0x0` and can draw using the parent bounds.