### PR TITLE
fix(video): parse Android source headers

### DIFF
--- a/.changeset/fix-android-video-source-headers.md
+++ b/.changeset/fix-android-video-source-headers.md
@@ -1,0 +1,5 @@
+---
+"@granite-js/video": patch
+---
+
+Fix Android video source headers parsing for React Native codegen header entries.

--- a/packages/video/android/src/main/java/run/granite/video/GraniteVideoView.kt
+++ b/packages/video/android/src/main/java/run/granite/video/GraniteVideoView.kt
@@ -66,11 +66,10 @@ class GraniteVideoView @JvmOverloads constructor(
     }
 
     // Source
-    @Suppress("UNCHECKED_CAST")
     fun setSource(source: Map<String, Any>?) {
         source ?: return
 
-        val headers = source["headers"] as? Map<String, String>
+        val headers = parseHeaders(source["headers"])
 
         val videoSource = GraniteVideoSource(
             uri = source["uri"] as? String,
@@ -113,13 +112,32 @@ class GraniteVideoView @JvmOverloads constructor(
             "clearkey" -> GraniteVideoDrmType.CLEARKEY
             else -> GraniteVideoDrmType.NONE
         }
-        val headers = map["headers"] as? Map<String, String>
+        val headers = parseHeaders(map["headers"])
         return GraniteVideoDrmConfig(
             type = drmType,
             licenseServer = map["licenseServer"] as? String,
             headers = headers,
             contentId = map["contentId"] as? String
         )
+    }
+
+    private fun parseHeaders(value: Any?): Map<String, String>? {
+        return when (value) {
+            is Map<*, *> -> value.entries.mapNotNull { (name, headerValue) ->
+                val headerName = name as? String ?: return@mapNotNull null
+                val headerStringValue = headerValue as? String ?: return@mapNotNull null
+                headerName to headerStringValue
+            }.toMap().ifEmpty { null }
+
+            is List<*> -> value.mapNotNull { entry ->
+                val header = entry as? Map<*, *> ?: return@mapNotNull null
+                val headerName = header["name"] as? String ?: return@mapNotNull null
+                val headerValue = header["value"] as? String ?: return@mapNotNull null
+                headerName to headerValue
+            }.toMap().ifEmpty { null }
+
+            else -> null
+        }
     }
 
     private fun parseMetadata(map: Map<String, Any>?): GraniteVideoMetadata? {

--- a/packages/video/android/src/test/java/run/granite/video/GraniteVideoViewRobolectricTest.kt
+++ b/packages/video/android/src/test/java/run/granite/video/GraniteVideoViewRobolectricTest.kt
@@ -125,6 +125,31 @@ class GraniteVideoViewRobolectricTest {
     }
 
     @Test
+    fun `setSource with codegen header entries should restore headers map`() {
+        val view = GraniteVideoView(
+            context = context,
+            providerFactory = { mockProvider }
+        )
+
+        val source = mapOf(
+            "uri" to "https://example.com/protected.m3u8",
+            "headers" to listOf(
+                mapOf(
+                    "name" to "X-Auth-Token",
+                    "value" to "test-secret"
+                )
+            )
+        )
+        view.setSource(source)
+
+        verify {
+            mockProvider.loadSource(match<GraniteVideoSource> {
+                it.headers == mapOf("X-Auth-Token" to "test-secret")
+            })
+        }
+    }
+
+    @Test
     fun `setSource with null source should not call loadSource`() {
         val view = GraniteVideoView(
             context = context,


### PR DESCRIPTION
## Summary
- parse Android video `source.headers` from both map and React Native codegen `{ name, value }` entries
- apply the same parsing to DRM headers
- add a Robolectric regression test for codegen header entries
- add a patch changeset for `@granite-js/video`

## Test Plan
- Not run per request.
- The same patch was validated downstream in toss-android alpha build and Android video `source.headers` E2E.