### PR TITLE
fix: horizontal `IntersectionObserver` ratio calculation

### DIFF
--- a/.changeset/witty-words-shave.md
+++ b/.changeset/witty-words-shave.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+Fix horizontal `IntersectionObserver` ratio calculation

--- a/packages/react-native/src/intersection-observer/IntersectionObserver.ts
+++ b/packages/react-native/src/intersection-observer/IntersectionObserver.ts
@@ -159,12 +159,12 @@ class IntersectionObserver {
           if (horizontal) {
             const visibleTargetMinX = Math.max(contentOffset.x - (rootMargin.left || 0), targetLayout.x);
             const visibleTargetMaxX = Math.min(
-              contentOffsetWithLayout + (rootMargin.left || 0),
+              contentOffsetWithLayout + (rootMargin.right || 0),
               targetLayout.x + targetLayout.width
             );
-            const visibleHeight = Math.max(visibleTargetMaxX - visibleTargetMinX, 0);
+            const visibleWidth = Math.max(visibleTargetMaxX - visibleTargetMinX, 0);
 
-            intersectionRatio = visibleHeight / targetLayout.height;
+            intersectionRatio = visibleWidth / targetLayout.width;
             isIntersecting =
               contentOffsetWithLayout + (rootMargin.right || 0) >= targetLayout.x &&
               contentOffset.x - (rootMargin.left || 0) <= targetLayout.x + targetLayout.width;


### PR DESCRIPTION
# Description

Fix horizontal `IntersectionObserver` ratio calculation to use visible width over target width

| Before | After |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/4ccb245e-76f9-4965-84d5-064d2497b6ad"> | <video src="https://github.com/user-attachments/assets/b75f6a87-e7e8-4fb8-bcfc-253f3e3ca92e"> |




