### PR TITLE
fix(android): remove `BackButton` default margin

### DIFF
--- a/.changeset/honest-laws-guess.md
+++ b/.changeset/honest-laws-guess.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+remove default margin

--- a/packages/react-native/src/router/components/BackButton.tsx
+++ b/packages/react-native/src/router/components/BackButton.tsx
@@ -89,7 +89,7 @@ const BACK_BUTTON_XML = Platform.select<string>({
 });
 
 const BACK_BUTTON_MARGIN = Platform.select<number>({
-  android: -4,
+  android: 0,
   ios: -12,
   default: -12,
 });


### PR DESCRIPTION
## Description

Remove `BackButton` default margin (`-4` to `0`)

| Before | After |
|:---:|:---:|
| <img width="564" height="262" alt="image (12)" src="https://github.com/user-attachments/assets/ba79232b-d4a2-4055-9e74-40e8cc7c2dd8" /> | <img width="496" height="284" alt="image (13)" src="https://github.com/user-attachments/assets/3107ff57-5d8c-4bf8-b7ea-423854ff31c2" /> |

