### PR TITLE
fix(react-native): restore useBackEventContext root export

### DIFF
--- a/.changeset/restore-back-event-context-export.md
+++ b/.changeset/restore-back-event-context-export.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+fix: restore `useBackEventContext` root export removed in 1.0.32

--- a/packages/react-native/src/use-back-event/index.ts
+++ b/packages/react-native/src/use-back-event/index.ts
@@ -1,2 +1,3 @@
 export * from './useBackEvent';
+export * from './useBackEventContext';
 export * from './useBackHandler';


### PR DESCRIPTION
## Problem

#310 moved `useBackEventContext` into its own file (`use-back-event/useBackEventContext.ts`), but the barrel file (`use-back-event/index.ts`) was not updated to re-export it. As a result, the hook silently disappeared from the package root exports starting from **1.0.32**, even though it had been part of the public surface up to 1.0.31 (re-exported through `useBackEvent.tsx`).

Since this shipped as a patch release, downstream consumers that depend on the export crash at runtime / fail to build when they pick up 1.0.32+:

- `@apps-in-toss/framework` (<= 2.10.4) — `TypeError: useBackEventContext is not a function` at runtime in navigation bar back handling
- `@toss/tds-react-native` (2.0.3) — esbuild link error: `No matching export in "@granite-js/react-native/src/index.ts" for import "useBackEventContext"`

## Fix

Restore the re-export in `use-back-event/index.ts` so the root export surface matches 1.0.31 again. The implementation file itself was never removed, so this is a one-line barrel change plus a patch changeset.

## Notes

Downstream libraries are migrating to the public APIs (`useRouterBackHandler` / `useBackHandler`); this restore keeps already-published versions working in the meantime. If the removal was intentional, consider deprecating first and removing in a major release.