### PR TITLE
fix(plugin-core): declare minimum Node.js version in engines

### DIFF
--- a/.changeset/declare-node-engines.md
+++ b/.changeset/declare-node-engines.md
@@ -1,0 +1,9 @@
+---
+'@granite-js/plugin-core': patch
+---
+
+Declare the minimum required Node.js version (`>=22.15.0`) in the `engines` field.
+
+`@granite-js/plugin-core` is a CJS bundle that does `require('c12')`, and c12 v3 is an ESM-only package. Under Yarn PnP, the `require(esm)` module graph is resolved with Node's default ESM resolver on Node.js < 22.15.0, ignoring the PnP loader hooks — so c12's own imports (e.g. `pathe`) fail with `ERR_MODULE_NOT_FOUND` at runtime. Node.js 22.15.0 routes `require(esm)` resolution through registered customization hooks (nodejs/node#55698), which makes it work with Yarn PnP.
+
+Declaring `engines` documents this requirement in a machine-readable way: npm prints an `EBADENGINE` warning at install time, pnpm fails the install with `engine-strict=true`, and deployment platforms and tooling pick up the field. Note that Yarn Berry does not enforce `engines`, so PnP users still need a matching Node.js version at runtime.

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -33,6 +33,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=22.15.0"
+  },
   "devDependencies": {
     "@types/node": "catalog:tools",
     "@vitest/coverage-v8": "^4.0.12",


### PR DESCRIPTION
## What

Declares the minimum required Node.js version (`>=22.15.0`) in the `engines` field of `@granite-js/plugin-core`.

## Problem

<img width="1078" height="921" alt="image" src="https://github.com/user-attachments/assets/da631ead-a6da-4528-97b6-b8f7aad80637" />


Running `granite dev` (or `build`) on Node.js < 22.15.0 in a Yarn PnP project crashes at startup with a hard-to-diagnose error:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'pathe' imported from /.../.yarn/__virtual__/c12-virtual-.../node_modules/c12/dist/index.mjs
Did you mean to import "pathe/dist/index.cjs"?
    at loadESMFromCJS (node:internal/modules/cjs/loader:1385:24)
```

Nothing warns about the Node.js version at install time, so users only hit this at runtime.

## Cause

- `@granite-js/plugin-core`'s CJS bundle (`dist/index.cjs`) calls `require('c12')`, and c12 v3 is an **ESM-only** package, so this goes through Node's `require(esm)` path.
- Yarn PnP registers its ESM resolution support as async customization hooks (`--experimental-loader .pnp.loader.mjs`).
- On Node.js <= 22.14, the `require(esm)` module graph is resolved with `#cachedDefaultResolve`, which **bypasses registered customization hooks entirely**. c12's own `import 'pathe'` is then resolved against the real filesystem (inside a zip, with no `node_modules`) and fails.
- Node.js 22.15.0 changed this path to `#cachedResolveSync`, which routes `require(esm)` resolution through the registered hooks (nodejs/node#55698), making it work under Yarn PnP.

Verified by bisecting: 22.12.0 / 22.13.0 / 22.14.0 all reproduce the exact error above, and 22.15.0 / 22.15.1 / 22.17.1 / 22.18.0 all work (`granite build` completes and `granite dev` starts normally on 22.15.0).

Note: this floor comes from the ESM-only dependency + `require(esm)` + Yarn PnP combination. It is unrelated to Node 22.18's type stripping — `granite.config.ts` is loaded via jiti.

## Effect

This declares the requirement in a machine-readable way. Verified behavior per package manager when installing on Node.js 22.14.0:

- npm: prints `EBADENGINE` warnings at install time (covers transitive dependencies too); hard-fails with `engine-strict=true`
- pnpm: fails the install with `ERR_PNPM_UNSUPPORTED_ENGINE` when `engine-strict=true` is set (silent by default)
- Yarn Berry: does **not** enforce `engines` (neither the project's own nor dependencies'), so PnP users are not protected at install time — for them the field serves as documentation, and is picked up by deployment platforms, Renovate, and the `yarn-plugin-engines` plugin

Since Yarn PnP users (where the failure actually occurs) get no install-time protection, a runtime Node.js version check in the CLI with a friendly error message would be a good follow-up.
