### PR TITLE
fix(react-native): stop forwarding InView API props to the host view

### DIFF
--- a/.changeset/wacky-ducks-tell.md
+++ b/.changeset/wacky-ducks-tell.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+fix(react-native): stop forwarding InView API props to the host view

--- a/packages/react-native/src/impression-area/ImpressionArea.tsx
+++ b/packages/react-native/src/impression-area/ImpressionArea.tsx
@@ -330,6 +330,12 @@ function ImpressionAreaImpl({
   return (
     <InView
       onChange={(inView, currentThreshold) => {
+        // Guard against non-observer invocations (e.g. a bubbling native event reaching
+        // the callback): a wrong `false` here sticks forever because the observer only
+        // re-notifies when its own `inView` value changes.
+        if (typeof inView !== 'boolean' || typeof currentThreshold !== 'number') {
+          return;
+        }
         const isVisible = inView && currentThreshold >= areaThreshold;
         setInviewImpressed(isVisible);
       }}

--- a/packages/react-native/src/intersection-observer/InView.spec.tsx
+++ b/packages/react-native/src/intersection-observer/InView.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { forwardRef } from 'react';
 import { View } from 'react-native';
 import { describe, expect, it, vi } from 'vitest';
 import IOContext, { IOContextValue } from './IOContext';
@@ -145,6 +146,33 @@ describe('InView', () => {
 
     expect(inner.unobserve).toHaveBeenCalledTimes(1);
     expect(outer.unobserve).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not forward its own API props (onChange, triggerOnce) to the rendered view', () => {
+    const manager = new FakeIntersectionObserverRegistry();
+    const onChange = vi.fn();
+    const received: Record<string, unknown>[] = [];
+    const CaptureView = forwardRef<View, Record<string, unknown>>((props, ref) => {
+      received.push(props);
+      return <View ref={ref} />;
+    });
+
+    render(
+      <IOContext.Provider value={{ manager: manager.asManager, parent: { manager: null } }}>
+        <InView as={CaptureView} triggerOnce onChange={onChange} testID="target">
+          <View />
+        </InView>
+      </IOContext.Provider>
+    );
+
+    const props = received.at(-1);
+    // API props must not leak: `onChange` on a host View is a bubbling event handler,
+    // so change events from descendants (e.g. TextInput) would call the observer
+    // callback with a SyntheticEvent.
+    expect(props).not.toHaveProperty('onChange');
+    expect(props).not.toHaveProperty('triggerOnce');
+    // Regular ViewProps still pass through.
+    expect(props).toHaveProperty('testID', 'target');
   });
 
   it('with triggerOnce, stops observing all ancestors once visible', () => {

--- a/packages/react-native/src/intersection-observer/InView.tsx
+++ b/packages/react-native/src/intersection-observer/InView.tsx
@@ -257,7 +257,12 @@ class InView<T = ViewProps> extends PureComponent<InViewProps<T>> {
   };
 
   render() {
-    const { as, children, ...props } = this.props;
+    // `onChange` and `triggerOnce` are InView's own API props and must not reach the
+    // rendered view. In React Native `onChange` is a bubbling event (`topChange`), so
+    // passing it through would make change events from descendants (e.g. a typing
+    // `TextInput`) invoke the observer callback with a SyntheticEvent instead of
+    // `(inView, intersectionRatio)`.
+    const { as, children, triggerOnce, onChange, ...props } = this.props;
     if (typeof children === 'function') {
       return null;
     }


### PR DESCRIPTION
## Problem

With an `IOScrollView > ImpressionArea > TextInput` hierarchy, typing into the
`TextInput` fires `onImpressionEnd`, and `onImpressionStart` never fires again —
not even after backgrounding and returning to the screen. The impression state is
permanently stuck.

## Root cause

`InView`'s `render()` spreads its remaining props onto the underlying host `View`,
which includes its own `onChange` API prop:

```tsx
const { as, children, ...props } = this.props; // onChange stays in props
return <ViewComponent {...props} ...>{children}</ViewComponent>;
```

In React Native, `onChange` is a **bubbling event** name (`topChange` →
`{bubbled: 'onChange'}`). Native change events emitted by a descendant
`TextInput` on every keystroke bubble up to the parent `View`, so the `onChange`
callback passed to `InView` gets invoked with a `SyntheticEvent` instead of its
documented `(inView: boolean, intersectionRatio: number)` signature.

In `ImpressionAreaImpl`, that mis-invocation silently evaluates to
`isVisible = false` and calls `setInviewImpressed(false)`.

The state then sticks permanently because two stores go out of sync:

- The observer's own `element.inView` stays `true` (the element never left the
  screen — the bubbling path doesn't touch it).
- The React state `inviewImpressed` is corrupted to `false`.
- The only sync path from the observer to React state is diff-gated
  (`target.inView !== isIntersecting` in `IntersectionObserver.ts`), so the
  observer never re-notifies, and `impressed = visible && inviewImpressed && enabled`
  stays `false` forever regardless of visibility changes.

## Fix

1. **Root fix** — exclude `InView`'s own API props (`onChange`, `triggerOnce`)
   from the spread in `render()`, so they never reach the host view. The observer
   path is unaffected: `handleChange` reads `this.props.onChange` directly.
   `onLayout` was already safe since it's explicitly overridden with
   `onLayout={this.handleLayout}`. All other `ViewProps` still pass through as
   intended.
2. **Defense in depth** — guard the `InView` `onChange` callback in
   `ImpressionAreaImpl` against non-observer invocations
   (`typeof inView !== 'boolean' || typeof currentThreshold !== 'number'`),
   since a single wrong `false` is unrecoverable due to the diff gate described
   above.

## Test plan

- Added a regression test asserting that `onChange`/`triggerOnce` are not
  forwarded to the rendered view while regular `ViewProps` (e.g. `testID`)
  still pass through.
- Existing suite: all 89 tests in `@granite-js/react-native` pass; `tsc --noEmit`
  and ESLint clean.
- Verified on device with the reproduction fixture: typing no longer invokes the
  `InView` callback with an event object, and `onImpressionStart` fires again
  after typing → background → foreground.  