### PR TITLE
fix(react-native): run CanGoBackGuard effects per platform and deprecated useBackEvent

### DIFF
--- a/.changeset/deprecate-use-back-event.md
+++ b/.changeset/deprecate-use-back-event.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+Deprecate `useBackEvent` in favor of `useBackHandler`. Handlers registered through `useBackHandler` receive a `BackEvent` object and can conditionally consume the back action by returning `true`. `useBackEvent` still works, but will be removed in a future release.

--- a/docs/ko/reference/manifest.json
+++ b/docs/ko/reference/manifest.json
@@ -96,6 +96,10 @@
                   "link": "/reference/react-native/screen-control/useBackEvent"
                 },
                 {
+                  "text": "useBackHandler",
+                  "link": "/reference/react-native/screen-control/useBackHandler"
+                },
+                {
                   "text": "useParams",
                   "link": "/reference/react-native/screen-control/useParams"
                 },

--- a/docs/ko/reference/react-native/screen-control/useBackEvent.md
+++ b/docs/ko/reference/react-native/screen-control/useBackEvent.md
@@ -4,6 +4,43 @@ sourcePath: packages/react-native/src/use-back-event/useBackEvent.tsx
 
 # useBackEvent
 
+::: warning 지원 종료 예정 (Deprecated)
+`useBackEvent`는 지원 종료 예정이에요. 이후 릴리스에서 제거되니 [useBackHandler](/ko/reference/react-native/screen-control/useBackHandler)를 사용하세요.
+
+`useBackHandler`로 등록한 핸들러는 `BackEvent` 객체를 받고, `true`를 반환해서 조건에 따라 뒤로 가기 동작을 가로챌 수 있어요. `useBackEvent`처럼 등록돼 있는 동안 항상 기본 뒤로 가기를 막으려면 핸들러에서 `true`를 반환하세요.
+
+```tsx
+// Before
+const backEvent = useBackEvent();
+
+useEffect(() => {
+  const listener = () => {
+    // 뒤로 가기 동작 처리
+  };
+
+  backEvent.addEventListener(listener);
+
+  return () => {
+    backEvent.removeEventListener(listener);
+  };
+}, [backEvent]);
+
+// After
+const backHandler = useBackHandler();
+
+useEffect(() => {
+  const subscription = backHandler.addEventListener(() => {
+    // 뒤로 가기 동작 처리
+    return true; // 기본 뒤로 가기 동작을 막아요
+  });
+
+  return () => {
+    subscription.remove();
+  };
+}, [backHandler]);
+```
+:::
+
 뒤로 가기 이벤트를 등록하고 제거할 수 있는 컨트롤러 객체를 반환하는 Hook이에요. 이 Hook을 사용하면 특정 컴포넌트가 활성화되었을 때만 뒤로 가기 이벤트를 처리할 수 있어요.
 `addEventListener` 를 쓰면 뒤로 가기 이벤트를 등록할 수 있고, `removeEventListener` 를 쓰면 뒤로 가기 이벤트를 제거할 수 있어요.
 사용자가 화면을 보고 있을 때만 등록된 뒤로 가기 이벤트가 등록돼요. 화면을 보고 있다는 조건은 [useVisibility](/ko/reference/react-native/screen-control/useVisibility) 을 사용해요.

--- a/docs/ko/reference/react-native/screen-control/useBackHandler.md
+++ b/docs/ko/reference/react-native/screen-control/useBackHandler.md
@@ -1,0 +1,85 @@
+---
+sourcePath: packages/react-native/src/use-back-event/useBackHandler.tsx
+---
+
+# useBackHandler
+
+뒤로 가기 동작을 가로채는 백 핸들러를 등록하는 Hook이에요. 이 Hook을 사용하면 뒤로 가기 버튼을 눌렀을 때 화면을 벗어나는 대신 오버레이를 먼저 닫는 것처럼, 조건에 따라 뒤로 가기 동작을 다르게 처리할 수 있어요.
+
+이 Hook은 지원 종료 예정인 [useBackEvent](/ko/reference/react-native/screen-control/useBackEvent)를 대체해요. 백 핸들러는 `useBackEvent`로 등록한 핸들러보다 먼저 실행돼요.
+
+`addEventListener`로 핸들러를 등록해요. 핸들러를 등록하면 구독 객체를 반환하고, 구독 객체의 `remove` 메서드를 호출하면 핸들러를 제거해요.
+
+뒤로 가기 동작(뒤로 가기 버튼, iOS 스와이프 제스처, Android 하드웨어 백 버튼)이 발생하면 등록된 핸들러가 등록 순서의 역순으로 실행돼요. 가장 나중에 등록한 핸들러가 가장 먼저 실행돼요. 각 핸들러는 뒤로 가기 동작의 출처(`source`)가 담긴 `BackEvent` 객체를 받아요.
+
+핸들러의 반환 값으로 뒤로 가기 동작을 이어갈지 결정해요.
+
+- `true`를 반환하면 뒤로 가기 동작이 여기서 끝나요. 남은 핸들러를 실행하지 않고, 기본 뒤로 가기 동작도 실행하지 않아요.
+- `false`를 반환하거나 아무것도 반환하지 않으면 다음 핸들러가 이어서 실행돼요.
+
+등록된 핸들러는 사용자가 화면을 보고 있을 때만 동작해요. 화면을 보고 있는지는 [useVisibility](/ko/reference/react-native/screen-control/useVisibility)로 판단해요.
+
+## 시그니처
+
+```typescript
+function useBackHandler(): BackHandlerControls;
+```
+
+### 반환 값
+
+<ul class="post-parameters-ul">
+  <li class="post-parameters-li post-parameters-li-root">
+    <span class="post-parameters--type">BackHandlerControls</span>
+    <br />
+    <p class="post-parameters--description">백 핸들러를 등록할 수 있는 객체예요. <code>addEventListener</code> 메서드로 <code>(event: BackEvent) =&gt; boolean | void</code> 타입의 핸들러를 등록해요. 이 메서드는 <code>remove</code> 메서드가 담긴 구독 객체를 반환하고, <code>remove</code>를 호출하면 등록한 핸들러를 제거해요.</p>
+  </li>
+</ul>
+
+### 에러
+
+<ul class="post-parameters-ul">
+  <li class="post-parameters-li post-parameters-li-root">
+    <span class="post-parameters--type">Error</span>
+    <br />
+    <p class="post-parameters--description">이 훅을 <code>BackEventProvider</code> 안에서 사용하지 않으면 에러가 발생해요.</p>
+  </li>
+</ul>
+
+## 예제
+
+### 오버레이를 먼저 닫는 예제
+
+- **오버레이가 열려 있을 때 뒤로 가기 버튼을 누르면, 뒤로 가는 대신 오버레이를 닫아요.** 핸들러가 `true`를 반환해서 뒤로 가기 동작이 여기서 끝나요.
+- **오버레이가 닫혀 있을 때 뒤로 가기 버튼을 누르면, 기존 동작대로 정상적으로 뒤로 가요.** 핸들러가 아무것도 반환하지 않아서 뒤로 가기 동작이 이어져요.
+
+```tsx
+import { useEffect, useState } from 'react';
+import { Button, View } from 'react-native';
+import { useBackHandler } from '@granite-js/react-native';
+
+export function OverlayExample() {
+  const backHandler = useBackHandler();
+  const [isOverlayOpen, setIsOverlayOpen] = useState(false);
+
+  useEffect(() => {
+    const subscription = backHandler.addEventListener(() => {
+      if (isOverlayOpen) {
+        setIsOverlayOpen(false);
+        return true;
+      }
+
+      return undefined;
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [backHandler, isOverlayOpen]);
+
+  return (
+    <View>
+      <Button title="Open Overlay" onPress={() => setIsOverlayOpen(true)} />
+    </View>
+  );
+}
+```

--- a/docs/reference/manifest.json
+++ b/docs/reference/manifest.json
@@ -98,6 +98,10 @@
                   "link": "/reference/react-native/screen-control/useBackEvent"
                 },
                 {
+                  "text": "useBackHandler",
+                  "link": "/reference/react-native/screen-control/useBackHandler"
+                },
+                {
                   "text": "useParams",
                   "link": "/reference/react-native/screen-control/useParams"
                 },

--- a/docs/reference/react-native/screen-control/useBackEvent.md
+++ b/docs/reference/react-native/screen-control/useBackEvent.md
@@ -4,6 +4,43 @@ sourcePath: packages/react-native/src/use-back-event/useBackEvent.tsx
 
 # useBackEvent
 
+::: warning Deprecated
+`useBackEvent` is deprecated and will be removed in a future release. Use [useBackHandler](./useBackHandler) instead.
+
+Handlers registered through `useBackHandler` receive a `BackEvent` object and can conditionally consume the back action by returning `true`. To keep the behavior of `useBackEvent` — always blocking default back navigation while registered — return `true` from the handler.
+
+```tsx
+// Before
+const backEvent = useBackEvent();
+
+useEffect(() => {
+  const listener = () => {
+    // handle back action
+  };
+
+  backEvent.addEventListener(listener);
+
+  return () => {
+    backEvent.removeEventListener(listener);
+  };
+}, [backEvent]);
+
+// After
+const backHandler = useBackHandler();
+
+useEffect(() => {
+  const subscription = backHandler.addEventListener(() => {
+    // handle back action
+    return true; // block default back navigation
+  });
+
+  return () => {
+    subscription.remove();
+  };
+}, [backHandler]);
+```
+:::
+
 A Hook that returns a controller object for registering and removing back events. Using this Hook, you can handle back events only when a specific component is active.
 Use `addEventListener` to register back events and `removeEventListener` to remove them.
 Registered back events are only active when the user is viewing the screen. The condition for viewing the screen is determined using [useVisibility](./useVisibility).

--- a/docs/reference/react-native/screen-control/useBackHandler.md
+++ b/docs/reference/react-native/screen-control/useBackHandler.md
@@ -1,0 +1,85 @@
+---
+sourcePath: packages/react-native/src/use-back-event/useBackHandler.tsx
+---
+
+# useBackHandler
+
+A Hook that registers back handlers which intercept back navigation. Using this Hook, you can handle a back action differently depending on conditions — for example, closing an overlay first instead of leaving the screen when the back button is pressed.
+
+This Hook replaces the deprecated [useBackEvent](./useBackEvent). Back handlers run before handlers registered through `useBackEvent`.
+
+Use `addEventListener` to register a handler. Registering a handler returns a subscription object, and calling its `remove` method removes the handler.
+
+When a back action occurs (back button, iOS swipe gesture, or Android hardware back press), registered handlers run in reverse registration order — the most recently registered handler runs first. Each handler receives a `BackEvent` object containing the `source` of the back action.
+
+The handler's return value decides whether the back action continues.
+
+- Return `true` to stop the back action there. The remaining handlers do not run, and the default back navigation does not run either.
+- Return `false` or return nothing to pass the back action to the next handler.
+
+Registered handlers are only active while the user is viewing the screen. Whether the screen is visible is determined using [useVisibility](./useVisibility).
+
+## Signature
+
+```typescript
+function useBackHandler(): BackHandlerControls;
+```
+
+### Return Value
+
+<ul class="post-parameters-ul">
+  <li class="post-parameters-li post-parameters-li-root">
+    <span class="post-parameters--type">BackHandlerControls</span>
+    <br />
+    <p class="post-parameters--description">An object that registers back handlers. Use the <code>addEventListener</code> method to register a handler of type <code>(event: BackEvent) =&gt; boolean | void</code>. This method returns a subscription object with a <code>remove</code> method, and calling <code>remove</code> removes the registered handler.</p>
+  </li>
+</ul>
+
+### Error
+
+<ul class="post-parameters-ul">
+  <li class="post-parameters-li post-parameters-li-root">
+    <span class="post-parameters--type">Error</span>
+    <br />
+    <p class="post-parameters--description">Throws an error if this hook is not used within a <code>BackEventProvider</code>.</p>
+  </li>
+</ul>
+
+## Example
+
+### Example of Closing an Overlay First
+
+- **While the overlay is open, pressing the back button closes the overlay instead of navigating back.** The handler returns `true`, so the back action stops there.
+- **While the overlay is closed, pressing the back button navigates back normally as per default behavior.** The handler returns nothing, so the back action continues.
+
+```tsx
+import { useEffect, useState } from 'react';
+import { Button, View } from 'react-native';
+import { useBackHandler } from '@granite-js/react-native';
+
+export function OverlayExample() {
+  const backHandler = useBackHandler();
+  const [isOverlayOpen, setIsOverlayOpen] = useState(false);
+
+  useEffect(() => {
+    const subscription = backHandler.addEventListener(() => {
+      if (isOverlayOpen) {
+        setIsOverlayOpen(false);
+        return true;
+      }
+
+      return undefined;
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [backHandler, isOverlayOpen]);
+
+  return (
+    <View>
+      <Button title="Open Overlay" onPress={() => setIsOverlayOpen(true)} />
+    </View>
+  );
+}
+```

--- a/packages/react-native/src/router/components/CanGoBackGuard.spec.tsx
+++ b/packages/react-native/src/router/components/CanGoBackGuard.spec.tsx
@@ -1,14 +1,24 @@
 import { render } from '@testing-library/react';
-import { BackHandler } from 'react-native';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BackHandler, Platform } from 'react-native';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CanGoBackGuard } from './CanGoBackGuard';
+
+function mockPlatformOS(os: typeof Platform.OS) {
+  vi.spyOn(Platform, 'OS', 'get').mockReturnValue(os);
+}
 
 describe('CanGoBackGuard', () => {
   beforeEach(() => {
     vi.mocked(BackHandler.addEventListener).mockClear();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('passes Android hardware back events to onBack and consumes the native event', () => {
+    mockPlatformOS('android');
+
     const onBack = vi.fn();
 
     render(
@@ -25,6 +35,8 @@ describe('CanGoBackGuard', () => {
   });
 
   it('does not register Android hardware back when no back event exists', () => {
+    mockPlatformOS('android');
+
     const onBack = vi.fn();
 
     render(
@@ -37,6 +49,8 @@ describe('CanGoBackGuard', () => {
   });
 
   it('registers the iOS swipe back handler while back events exist', () => {
+    mockPlatformOS('ios');
+
     const onBack = vi.fn();
     const setiOSBackPressHandler = vi.fn();
 
@@ -63,6 +77,8 @@ describe('CanGoBackGuard', () => {
   });
 
   it('disables iOS swipe when the current state should block default back navigation', () => {
+    mockPlatformOS('ios');
+
     const setIosSwipeGestureEnabled = vi.fn();
 
     const { unmount } = render(

--- a/packages/react-native/src/router/components/CanGoBackGuard.tsx
+++ b/packages/react-native/src/router/components/CanGoBackGuard.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect } from 'react';
-import { BackHandler } from 'react-native';
+import { BackHandler, Platform } from 'react-native';
 import type { BackEvent } from '../../use-back-event';
 
 type SetIosSwipeGestureEnabled = ({ isEnabled }: { isEnabled: boolean }) => Promise<void> | void;
@@ -23,6 +23,10 @@ export function CanGoBackGuard({
   setiOSBackPressHandler?: SetIOSBackPressHandler;
 }) {
   useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      return;
+    }
+
     if (!isInitialScreen || !canGoBack) {
       setIosSwipeGestureEnabled?.({ isEnabled: false });
 
@@ -35,6 +39,10 @@ export function CanGoBackGuard({
   }, [canGoBack, isInitialScreen, setIosSwipeGestureEnabled]);
 
   useEffect(() => {
+    if (Platform.OS !== 'android') {
+      return;
+    }
+
     if (!hasBackEvent) {
       return;
     }
@@ -51,6 +59,10 @@ export function CanGoBackGuard({
   }, [hasBackEvent, onBack]);
 
   useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      return;
+    }
+
     if (!hasBackEvent || setiOSBackPressHandler == null) {
       return;
     }

--- a/packages/react-native/src/use-back-event/useBackEvent.tsx
+++ b/packages/react-native/src/use-back-event/useBackEvent.tsx
@@ -218,6 +218,11 @@ export function useBackEventState() {
 }
 
 /**
+ * @deprecated Use `useBackHandler` instead. This will be removed in a future release.
+ * Handlers registered through `useBackHandler` receive a `BackEvent` object and can conditionally
+ * consume the back action by returning `true`. To keep the behavior of `useBackEvent`
+ * (always blocking default back navigation while registered), return `true` from the handler.
+ *
  * @public
  * @category Screen Control
  * @name useBackEvent


### PR DESCRIPTION
## What

### Gate `CanGoBackGuard` effects by platform

`CanGoBackGuard` registered all of its back-navigation effects on every platform. Each effect now runs only on the platform it targets:

- The iOS swipe-gesture toggle (`setIosSwipeGestureEnabled`) and the iOS back-press handler (`setiOSBackPressHandler`) run only when `Platform.OS === 'ios'`.
- The Android hardware back listener (`BackHandler.addEventListener`) runs only when `Platform.OS === 'android'`.

Tests now mock `Platform.OS` per case to cover both platforms.

### Deprecate `useBackEvent` in favor of `useBackHandler`

- Added a `@deprecated` JSDoc tag to `useBackEvent`, pointing to `useBackHandler`. It still works, but will be removed in a future release.
- Handlers registered through `useBackHandler` receive a `BackEvent` object and can conditionally consume the back action by returning `true`. To keep the old `useBackEvent` behavior (always blocking default back navigation while registered), return `true` from the handler.
- Docs (en/ko):
  - Added a deprecation notice with a before/after migration example to the `useBackEvent` reference.
  - Added a new `useBackHandler` reference page and registered it in the manifests.
- Added a patch changeset for `@granite-js/react-native`.