### PR TITLE
fix(cookies): parse ISO 8601 expires with milliseconds and fail loudly on invalid dates

### DIFF
--- a/.changeset/fix-cookies-expires-iso-parse.md
+++ b/.changeset/fix-cookies-expires-iso-parse.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/cookies': patch
+---
+
+Fix `expires` date parsing in the native cookie modules. ISO 8601 strings with milliseconds — the exact output of JavaScript's `Date.prototype.toISOString()` (e.g. `2024-01-01T00:00:00.000Z`) — failed to parse on iOS (`ISO8601DateFormatter` without `.withFractionalSeconds`) and on Android (`SimpleDateFormat` zone letters cannot match the literal `Z` suffix). Worse, both platforms silently dropped the `expires` attribute on parse failure, so the cookie was stored as a session cookie without any error. Now both platforms parse ISO 8601 with and without milliseconds, and `set` rejects an unparseable `expires` value with a descriptive error instead of silently creating a session cookie.

--- a/packages/cookies/android/src/main/kotlin/run/granite/cookies/CookiesModule.kt
+++ b/packages/cookies/android/src/main/kotlin/run/granite/cookies/CookiesModule.kt
@@ -151,9 +151,12 @@ class CookiesModule(reactContext: ReactContext) : BrickModuleSpec(reactContext),
             builder.append("; domain=$cleanDomain")
         }
         cookie.expires?.let { expires ->
-            parseExpiresDate(expires)?.let { date ->
-                builder.append("; expires=${formatDateRfc1123(date)}")
-            }
+            val date =
+                    parseExpiresDate(expires)
+                            ?: throw IllegalArgumentException(
+                                    String.format(INVALID_EXPIRES_ERROR, expires)
+                            )
+            builder.append("; expires=${formatDateRfc1123(date)}")
         }
         cookie.secure?.let { if (it) builder.append("; secure") }
 
@@ -247,21 +250,30 @@ class CookiesModule(reactContext: ReactContext) : BrickModuleSpec(reactContext),
     }
 
     private fun parseExpiresDate(expires: String): Date? {
-        // Try ISO 8601 format
-        try {
-            val isoFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ", Locale.US)
-            isoFormatter.timeZone = TimeZone.getTimeZone("GMT")
-            return isoFormatter.parse(expires)
-        } catch (_: Exception) {}
+        // The literal-'Z' patterns cover JavaScript's Date.prototype.toISOString output
+        // (always UTC, e.g. "2024-01-01T00:00:00.000Z"), which SimpleDateFormat's
+        // zone letters cannot parse reliably
+        val datePatterns =
+                listOf(
+                        // ISO 8601, UTC ("Z" suffix), with and without milliseconds
+                        "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+                        "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                        // ISO 8601 with explicit zone offset
+                        "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ",
+                        "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+                        // RFC 1123
+                        "EEE, dd MMM yyyy HH:mm:ss zzz"
+                )
 
-        // Try RFC 1123 format
-        try {
-            val rfc1123Formatter = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
-            rfc1123Formatter.timeZone = TimeZone.getTimeZone("GMT")
-            return rfc1123Formatter.parse(expires)
-        } catch (_: Exception) {}
+        for (pattern in datePatterns) {
+            try {
+                val formatter = SimpleDateFormat(pattern, Locale.US)
+                formatter.timeZone = TimeZone.getTimeZone("GMT")
+                return formatter.parse(expires) ?: continue
+            } catch (_: Exception) {}
+        }
 
-        // Try as timestamp
+        // Try as Unix timestamp in milliseconds
         try {
             val timestamp = expires.toDouble()
             return Date((timestamp).toLong())
@@ -280,5 +292,7 @@ class CookiesModule(reactContext: ReactContext) : BrickModuleSpec(reactContext),
         private const val INVALID_URL_ERROR = "Invalid URL: %s"
         private const val INVALID_COOKIE_VALUES = "Failed to create cookie from provided data"
         private const val INVALID_DOMAINS = "Cookie URL host %s and domain %s mismatched"
+        private const val INVALID_EXPIRES_ERROR =
+                "Invalid expires date: %s. Supported formats: ISO 8601 (e.g. 2024-01-01T00:00:00.000Z), RFC 1123 (e.g. Mon, 01 Jan 2024 00:00:00 GMT), or Unix timestamp in milliseconds"
     }
 }

--- a/packages/cookies/ios/CookiesModule.swift
+++ b/packages/cookies/ios/CookiesModule.swift
@@ -24,7 +24,7 @@ public final class CookiesModule: BrickModuleBase, CookiesSpec, @unchecked Senda
             throw BrickModuleError.executionError("Invalid URL: \(url)")
         }
 
-        guard let httpCookie = makeHTTPCookie(from: cookie, url: urlObj) else {
+        guard let httpCookie = try makeHTTPCookie(from: cookie, url: urlObj) else {
             throw BrickModuleError.executionError("Failed to create cookie from provided data")
         }
 
@@ -196,7 +196,7 @@ public final class CookiesModule: BrickModuleBase, CookiesSpec, @unchecked Senda
 
     // MARK: - Helper Methods
 
-    private func makeHTTPCookie(from cookie: CookiesCookie, url: URL) -> HTTPCookie? {
+    private func makeHTTPCookie(from cookie: CookiesCookie, url: URL) throws -> HTTPCookie? {
         var properties: [HTTPCookiePropertyKey: Any] = [
             .name: cookie.name,
             .value: cookie.value,
@@ -214,9 +214,14 @@ public final class CookiesModule: BrickModuleBase, CookiesSpec, @unchecked Senda
 
         // Expiration handling
         if let expires = cookie.expires {
-            if let expiresDate = Self.parseExpiresDate(expires) {
-                properties[.expires] = expiresDate
+            guard let expiresDate = Self.parseExpiresDate(expires) else {
+                throw BrickModuleError.executionError(
+                    "Invalid expires date: \(expires). " +
+                    "Supported formats: ISO 8601 (e.g. 2024-01-01T00:00:00.000Z), " +
+                    "RFC 1123 (e.g. Mon, 01 Jan 2024 00:00:00 GMT), or Unix timestamp in milliseconds"
+                )
             }
+            properties[.expires] = expiresDate
         }
 
         // Secure flag
@@ -233,7 +238,15 @@ public final class CookiesModule: BrickModuleBase, CookiesSpec, @unchecked Senda
     }
 
     private static func parseExpiresDate(_ expires: String) -> Date? {
-        // Try ISO 8601 format first
+        // Try ISO 8601 with fractional seconds first
+        // (JavaScript's Date.prototype.toISOString produces e.g. "2024-01-01T00:00:00.000Z")
+        let isoFractionalFormatter = ISO8601DateFormatter()
+        isoFractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = isoFractionalFormatter.date(from: expires) {
+            return date
+        }
+
+        // Try ISO 8601 without fractional seconds
         let isoFormatter = ISO8601DateFormatter()
         if let date = isoFormatter.date(from: expires) {
             return date


### PR DESCRIPTION
## What

Fixes `expires` date parsing in the `@granite-js/cookies` native modules on both platforms:

- **iOS**: `parseExpiresDate` used a default `ISO8601DateFormatter`, which cannot parse ISO 8601 strings containing fractional seconds. Since JavaScript's `Date.prototype.toISOString()` always emits milliseconds (e.g. `2024-01-01T00:00:00.000Z`), the most common way to produce an `expires` value from JS never parsed. Now an `ISO8601DateFormatter` with `.withFractionalSeconds` is tried first, falling back to the non-fractional variant.
- **Android**: the only ISO pattern was `yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ`, whose zone letters cannot reliably match the literal `Z` suffix of `toISOString()` output. Added literal-`'Z'` UTC patterns (with and without milliseconds) tried first, keeping the existing offset/RFC 1123/timestamp fallbacks.
- **Both**: on parse failure, the native modules used to *silently drop* the `expires` attribute and store the cookie as a session cookie — the caller got `true` back and had no way to know the expiration was lost. `set` now rejects an unparseable `expires` with a descriptive error listing the supported formats.

## Why

The cookie `expires` field is documented as "ISO string or timestamp", but passing the canonical JS ISO string silently produced a session cookie. Session cookies live only in memory, so when iOS kills the WebKit network process of a backgrounded app, the cookie disappears — surfacing downstream as apps losing state they believed was persisted for weeks. The silent fallback made this effectively undebuggable from the JS side, since `CookieManager.set` resolved successfully.

## How it was verified

Ran replicas of the exact parsing logic (old vs. new) as standalone scripts:

- **iOS** (`swift` on macOS, same Foundation `ISO8601DateFormatter`), also constructing the resulting `HTTPCookie` to check `isSessionOnly`:

| input | old parse | new parse | resulting cookie |
| --- | --- | --- | --- |
| `2024-01-01T00:00:00.000Z` (`toISOString`) | **nil → session cookie** | ✅ parsed | persistent (`isSessionOnly=false`) |
| `2024-01-01T00:00:00Z` | parsed | ✅ parsed | persistent |
| `Mon, 01 Jan 2024 00:00:00 GMT` (RFC 1123) | parsed | ✅ parsed | persistent |
| Unix timestamp (ms) | parsed | ✅ parsed | persistent |
| garbage string | nil → session cookie | nil → **error thrown** | — |

- **Android** (`java` with the same `java.text.SimpleDateFormat` semantics): the new literal-`'Z'` patterns parse `toISOString()` output (with and without milliseconds) to the correct epoch; RFC 1123 and millisecond-timestamp behavior is unchanged.

- `swiftc -parse` passes on the modified Swift file; `yarn workspace @granite-js/cookies build` (brick-codegen + tsdown) succeeds with no generated-file drift.

## Notes for reviewers

- Rejecting an invalid `expires` (instead of silently storing a session cookie) is a behavior change for callers that were passing unparseable dates — but those callers were already not getting what they asked for; they were just never told.
- Android's `parseExpiresDate` intentionally keeps lenient `SimpleDateFormat` parsing: strict mode would reject RFC 1123 dates whose weekday doesn't match the date, which the previous implementation accepted.
