### PR TITLE
feat(shared): add micro-frontend host example

### DIFF
--- a/services/bare/babel.config.js
+++ b/services/bare/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['babel-preset-granite'],
+};

--- a/services/bare/granite.config.ts
+++ b/services/bare/granite.config.ts
@@ -1,0 +1,17 @@
+import { microFrontend } from '@granite-js/micro-frontend/plugin';
+import { hermes } from '@granite-js/plugin-hermes';
+import { defineConfig } from '@granite-js/react-native/config';
+
+export default defineConfig({
+  appName: 'bare',
+  scheme: 'granite',
+  plugins: [
+    hermes(),
+    microFrontend({
+      exposes: {
+        './App': './src/_app.tsx',
+      },
+      shared: ['react', 'react-native'],
+    }),
+  ],
+});

--- a/services/bare/index.ts
+++ b/services/bare/index.ts
@@ -1,0 +1,4 @@
+import { register } from '@granite-js/react-native';
+import App from './src/App';
+
+register(App);

--- a/services/bare/package.json
+++ b/services/bare/package.json
@@ -1,42 +1,27 @@
 {
-  "name": "@granite-app/showcase",
+  "name": "@granite-app/bare",
   "private": true,
   "scripts": {
     "dev": "granite dev --experimental-mode",
     "build": "granite build",
-    "test": "vitest --run --passWithNoTests",
     "typecheck": "tsc --noEmit",
     "lint": "biome check --write"
   },
   "dependencies": {
-    "@granite-js/native": "workspace:*",
     "@granite-js/react-native": "workspace:*",
-    "brick-module": "catalog:brick-module",
     "react": "catalog:react-native",
-    "react-native": "catalog:react-native",
-    "valibot": "^1.1.0",
-    "zod": "^4.1.12"
+    "react-native": "catalog:react-native"
   },
   "devDependencies": {
     "@babel/core": "7.28.5",
     "@babel/runtime": "7.18.9",
-    "@biomejs/biome": "^1.9.4",
     "@granite-js/forge-cli": "workspace:*",
     "@granite-js/micro-frontend": "workspace:*",
-    "@granite-js/plugin-env": "workspace:*",
     "@granite-js/plugin-hermes": "workspace:*",
-    "@granite-js/plugin-router": "workspace:*",
-    "@granite-js/plugin-sentry": "workspace:*",
-    "@granite-js/vitest": "workspace:*",
     "@react-native/babel-preset": "catalog:react-native",
-    "@testing-library/react-native": "^12.9.0",
-    "@types/babel__core": "^7.20.5",
     "@types/node": "catalog:tools",
     "@types/react": "catalog:react-native",
-    "@types/react-test-renderer": "19.1.0",
     "babel-preset-granite": "workspace:*",
-    "react-test-renderer": "19.2.3",
-    "typescript": "catalog:tools",
-    "vitest": "4.1.3"
+    "typescript": "catalog:tools"
   }
 }

--- a/services/bare/src/App.tsx
+++ b/services/bare/src/App.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Bare App</Text>
+      <Text style={styles.description}>This screen was loaded from the bare micro-frontend bundle.</Text>
+      <Text style={styles.count}>Count: {count}</Text>
+      <Pressable
+        accessibilityRole="button"
+        style={styles.button}
+        onPress={() => setCount((current) => current + 1)}
+      >
+        <Text style={styles.buttonLabel}>Increment Count</Text>
+      </Pressable>
+      <Pressable
+        accessibilityRole="button"
+        style={styles.button}
+        onPress={() => Linking.openURL('granite://showcase')}
+      >
+        <Text style={styles.buttonLabel}>Open Showcase App</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+    backgroundColor: 'white',
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#1A202C',
+    marginBottom: 12,
+  },
+  description: {
+    fontSize: 16,
+    color: '#4A5568',
+    textAlign: 'center',
+  },
+  count: {
+    marginTop: 20,
+    fontSize: 20,
+    color: '#1A202C',
+  },
+  button: {
+    marginTop: 16,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: '#0064FF',
+  },
+  buttonLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: 'white',
+  },
+});

--- a/services/bare/src/_app.tsx
+++ b/services/bare/src/_app.tsx
@@ -1,0 +1,1 @@
+export { default } from './App';

--- a/services/bare/tsconfig.json
+++ b/services/bare/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "jsx": "react-native"
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/services/shared/README.md
+++ b/services/shared/README.md
@@ -1,1 +1,49 @@
-# shared
+# Shared micro-frontend host
+
+The shared app keeps its existing single-app track and enables the mono-Hermes micro-frontend host when native passes
+`{ _monoHermes: true }` as an initial prop.
+
+```text
+preloadApp/openApp native event
+  -> adapter.loadBundle(appName)
+  -> GraniteMicroFrontendRuntime.evaluateScript({ filePath })
+  -> importApp(`${appName}/App`)
+  -> Portal mounted with the native sessionId
+```
+
+## Example bundle loader
+
+[`src/micro-frontend/runtime.ts`](./src/micro-frontend/runtime.ts) is a deliberately small adapter for the two example
+apps, `bare` and `showcase`. It delegates download, verification, and caching to this object-based TurboModule:
+
+```ts
+interface GraniteExampleMicroFrontendBundleLoader extends TurboModule {
+  loadBundle(request: {
+    readonly appName: 'bare' | 'showcase';
+  }): Promise<string>;
+}
+```
+
+`loadBundle()` returns the absolute path of the locally cached bundle. The native example host can map the app name to
+development servers or production bundle storage without putting URLs in the JavaScript runtime contract.
+
+Start the independent development bundles with:
+
+```bash
+yarn workspace @granite-app/shared dev --port 8081
+yarn workspace @granite-app/bare dev --port 8082
+yarn workspace @granite-app/showcase dev --port 8083
+```
+
+Both remote apps use `@granite-js/micro-frontend/plugin` and expose `./App`. The plugin derives each container name
+from its `appName` in `granite.config.ts`.
+
+## Session lifecycle
+
+[`MonoHermesMainPageTrack`](./src/pages/MonoHermesMainPageTrack.tsx) consumes `preloadApp`, `openApp`, `closeApp`, and
+`sessionVisibilityChanged` events. Its reducer owns the React session trees; native owns screen closure and sends
+`closeApp` after the transition completes.
+
+Every mounted root uses the native `sessionId` as its Portal host name and
+`nativeID="micro-frontend-session:<sessionId>"`. Remote apps read visibility and request close through
+`MicroFrontendSessionProvider` instead of receiving the session identifier as an app prop.

--- a/services/shared/granite.config.ts
+++ b/services/shared/granite.config.ts
@@ -1,5 +1,5 @@
+import { microFrontend } from '@granite-js/micro-frontend/plugin';
 import { hermes } from '@granite-js/plugin-hermes';
-import { microFrontend } from '@granite-js/plugin-micro-frontend';
 import { defineConfig } from '@granite-js/react-native/config';
 
 const SHARED_MODULES = [
@@ -24,11 +24,6 @@ export default defineConfig({
   plugins: [
     hermes(),
     microFrontend({
-      name: 'shared',
-      remote: {
-        host: 'localhost',
-        port: 8082,
-      },
       shared: SHARED_MODULES.reduce(
         (prev, packageName) => ({
           ...prev,

--- a/services/shared/package.json
+++ b/services/shared/package.json
@@ -3,13 +3,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "granite dev",
+    "dev": "granite dev --experimental-mode",
     "build": "granite build --no-cache",
+    "test": "vitest --run",
     "typecheck": "tsc --noEmit",
     "lint": "biome check --write"
   },
   "dependencies": {
+    "@granite-js/micro-frontend": "workspace:*",
     "@granite-js/mpack": "workspace:*",
+    "@granite-js/portal": "workspace:*",
     "@granite-js/react-native": "workspace:*",
     "@react-native-async-storage/async-storage": "catalog:react-native",
     "@react-native-community/blur": "catalog:react-native",
@@ -33,10 +36,11 @@
     "@granite-js/forge-cli": "workspace:*",
     "@granite-js/native": "workspace:*",
     "@granite-js/plugin-hermes": "workspace:*",
-    "@granite-js/plugin-micro-frontend": "workspace:*",
+    "@granite-js/vitest": "workspace:*",
     "@react-native/babel-preset": "catalog:react-native",
     "@types/node": "catalog:tools",
     "@types/react": "catalog:react-native",
-    "typescript": "catalog:tools"
+    "typescript": "catalog:tools",
+    "vitest": "^4.0.12"
   }
 }

--- a/services/shared/src/micro-frontend/runtime.spec.ts
+++ b/services/shared/src/micro-frontend/runtime.spec.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadBundle } from './runtime';
+
+const { nativeLoadBundle } = vi.hoisted(() => ({
+  nativeLoadBundle: vi.fn(async ({ appName }: { readonly appName: string }) => `/bundles/${appName}.hbc`),
+}));
+
+vi.mock('react-native', () => ({
+  TurboModuleRegistry: {
+    getEnforcing: vi.fn(() => ({ loadBundle: nativeLoadBundle })),
+  },
+}));
+
+vi.mock('@granite-js/micro-frontend', () => ({
+  createMicroFrontendRuntime: vi.fn(() => ({})),
+}));
+
+describe('example micro-frontend bundle loader', () => {
+  beforeEach(() => {
+    nativeLoadBundle.mockClear();
+  });
+
+  it.each(['bare', 'showcase'] as const)('loads the %s app through an object request', async (appName) => {
+    await expect(loadBundle(appName)).resolves.toBe(`/bundles/${appName}.hbc`);
+    expect(nativeLoadBundle).toHaveBeenLastCalledWith({ appName });
+  });
+
+  it('rejects apps outside the example allowlist', async () => {
+    await expect(loadBundle('unknown')).rejects.toThrow('Unknown example app: unknown');
+    expect(nativeLoadBundle).not.toHaveBeenCalled();
+  });
+});

--- a/services/shared/src/micro-frontend/runtime.ts
+++ b/services/shared/src/micro-frontend/runtime.ts
@@ -1,0 +1,23 @@
+import { createMicroFrontendRuntime } from '@granite-js/micro-frontend';
+import { TurboModuleRegistry, type TurboModule } from 'react-native';
+
+type ExampleAppName = 'bare' | 'showcase';
+
+interface NativeExampleBundleLoader extends TurboModule {
+  readonly loadBundle: (request: { readonly appName: ExampleAppName }) => Promise<string>;
+}
+
+export function loadBundle(appName: string): Promise<string> {
+  if (appName !== 'bare' && appName !== 'showcase') {
+    return Promise.reject(new Error(`Unknown example app: ${appName}`));
+  }
+
+  const nativeBundleLoader = TurboModuleRegistry.getEnforcing<NativeExampleBundleLoader>(
+    'GraniteExampleMicroFrontendBundleLoader'
+  );
+  return nativeBundleLoader.loadBundle({ appName });
+}
+
+export const microFrontendRuntime = createMicroFrontendRuntime({
+  adapter: { loadBundle },
+});

--- a/services/shared/src/micro-frontend/session.spec.ts
+++ b/services/shared/src/micro-frontend/session.spec.ts
@@ -1,0 +1,34 @@
+import { lazy } from 'react';
+import { describe, expect, it } from 'vitest';
+import { reduceMicroFrontendSessions } from './session';
+
+const SESSION = {
+  sessionId: 'session-1',
+  scheme: 'granite://showcase',
+  isVisible: false,
+  App: lazy(async () => ({ default: () => null })),
+} as const;
+
+describe('reduceMicroFrontendSessions', () => {
+  it('opens, updates, and closes a session by native session id', () => {
+    const opened = reduceMicroFrontendSessions([], { type: 'opened', session: SESSION });
+    const visible = reduceMicroFrontendSessions(opened, {
+      type: 'visibilityChanged',
+      sessionId: SESSION.sessionId,
+      isVisible: true,
+    });
+    const closed = reduceMicroFrontendSessions(visible, {
+      type: 'closed',
+      sessionId: SESSION.sessionId,
+    });
+
+    expect(visible).toEqual([{ ...SESSION, isVisible: true }]);
+    expect(closed).toEqual([]);
+  });
+
+  it('ignores duplicate open events', () => {
+    const sessions = [SESSION];
+
+    expect(reduceMicroFrontendSessions(sessions, { type: 'opened', session: SESSION })).toBe(sessions);
+  });
+});

--- a/services/shared/src/micro-frontend/session.ts
+++ b/services/shared/src/micro-frontend/session.ts
@@ -1,0 +1,45 @@
+import type { InitialProps } from '@granite-js/react-native';
+import type { ComponentType, LazyExoticComponent } from 'react';
+
+export const MICRO_FRONTEND_SESSION_NATIVE_ID_PREFIX = 'micro-frontend-session:';
+
+export interface AppModule {
+  readonly default: ComponentType<InitialProps>;
+}
+
+export interface MicroFrontendSession {
+  readonly sessionId: string;
+  readonly scheme: string;
+  readonly isVisible: boolean;
+  readonly App: LazyExoticComponent<ComponentType<InitialProps>>;
+}
+
+export type MicroFrontendSessionAction =
+  | { readonly type: 'opened'; readonly session: MicroFrontendSession }
+  | { readonly type: 'closed'; readonly sessionId: string }
+  | {
+      readonly type: 'visibilityChanged';
+      readonly sessionId: string;
+      readonly isVisible: boolean;
+    };
+
+export function reduceMicroFrontendSessions(
+  sessions: readonly MicroFrontendSession[],
+  action: MicroFrontendSessionAction
+): readonly MicroFrontendSession[] {
+  switch (action.type) {
+    case 'opened':
+      return sessions.some(({ sessionId }) => sessionId === action.session.sessionId)
+        ? sessions
+        : [...sessions, action.session];
+    case 'closed':
+      return sessions.filter(({ sessionId }) => sessionId !== action.sessionId);
+    case 'visibilityChanged':
+      return sessions.map((session) =>
+        session.sessionId === action.sessionId ? { ...session, isVisible: action.isVisible } : session
+      );
+    default:
+      action satisfies never;
+      return sessions;
+  }
+}

--- a/services/shared/src/pages/MainPage.tsx
+++ b/services/shared/src/pages/MainPage.tsx
@@ -2,19 +2,28 @@ import type { InitialProps } from '@granite-js/react-native';
 import { ErrorBoundary } from '@toss/error-boundary';
 import React, { Suspense } from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { MonoHermesMainPageTrack } from './MonoHermesMainPageTrack';
 import { ErrorPage } from '../components/ErrorPage';
 import { loadAppContent } from '../utils/loadAppContent';
 
-const AppContent = React.lazy(() => loadAppContent('remoteApp/AppContainer'));
+const AppContent = React.lazy(() => loadAppContent('showcase/App'));
 
-export function MainPage(props: InitialProps) {
+export type SharedInitialProps = InitialProps & {
+  readonly _monoHermes?: boolean;
+};
+
+export function MainPage(props: SharedInitialProps) {
   return (
     <ErrorBoundary renderFallback={(props) => <ErrorPage reason={props.error.message} />}>
-      <SafeAreaProvider>
-        <Suspense fallback={null}>
-          <AppContent {...props} />
-        </Suspense>
-      </SafeAreaProvider>
+      {props._monoHermes === true ? (
+        <MonoHermesMainPageTrack initialProps={props} />
+      ) : (
+        <SafeAreaProvider>
+          <Suspense fallback={null}>
+            <AppContent {...props} />
+          </Suspense>
+        </SafeAreaProvider>
+      )}
     </ErrorBoundary>
   );
 }

--- a/services/shared/src/pages/MonoHermesMainPageTrack.tsx
+++ b/services/shared/src/pages/MonoHermesMainPageTrack.tsx
@@ -1,0 +1,130 @@
+import { MicroFrontendSessionProvider, type MicroFrontendRuntimeEvent } from '@granite-js/micro-frontend';
+import { Portal, PortalProvider } from '@granite-js/portal';
+import type { InitialProps } from '@granite-js/react-native';
+import {
+  Component,
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useReducer,
+  type PropsWithChildren,
+} from 'react';
+import { StyleSheet, View } from 'react-native';
+import { ErrorPage } from '../components/ErrorPage';
+import { microFrontendRuntime } from '../micro-frontend/runtime';
+import {
+  type AppModule,
+  MICRO_FRONTEND_SESSION_NATIVE_ID_PREFIX,
+  type MicroFrontendSession,
+  reduceMicroFrontendSessions,
+} from '../micro-frontend/session';
+
+function reportMicroFrontendError(error: unknown): void {
+  console.error('[micro-frontend] Failed to preload app', error);
+}
+
+interface SessionErrorBoundaryState {
+  readonly error: Error | null;
+}
+
+class SessionErrorBoundary extends Component<PropsWithChildren, SessionErrorBoundaryState> {
+  state: SessionErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): SessionErrorBoundaryState {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error != null) {
+      return <ErrorPage reason={this.state.error.message} />;
+    }
+    return this.props.children;
+  }
+}
+
+function SessionRoot({
+  initialProps,
+  session,
+}: {
+  readonly initialProps: InitialProps;
+  readonly session: MicroFrontendSession;
+}) {
+  const close = useCallback(() => microFrontendRuntime.closeSession(session.sessionId), [session.sessionId]);
+  const { App } = session;
+
+  return (
+    <Portal hostName={session.sessionId}>
+      <View
+        collapsable={false}
+        nativeID={`${MICRO_FRONTEND_SESSION_NATIVE_ID_PREFIX}${session.sessionId}`}
+        style={StyleSheet.absoluteFill}
+      >
+        <MicroFrontendSessionProvider sessionId={session.sessionId} isVisible={session.isVisible} close={close}>
+          <SessionErrorBoundary>
+            <Suspense fallback={null}>
+              <App {...initialProps} scheme={session.scheme} />
+            </Suspense>
+          </SessionErrorBoundary>
+        </MicroFrontendSessionProvider>
+      </View>
+    </Portal>
+  );
+}
+
+export function MonoHermesMainPageTrack({ initialProps }: { readonly initialProps: InitialProps }) {
+  const [sessions, dispatch] = useReducer(reduceMicroFrontendSessions, []);
+
+  useEffect(() => {
+    const subscription = microFrontendRuntime.onEvent((event: MicroFrontendRuntimeEvent) => {
+      switch (event.name) {
+        case 'preloadApp':
+          void microFrontendRuntime.preloadApp(event.params.appName).catch(reportMicroFrontendError);
+          return;
+        case 'openApp': {
+          const { appName, scheme, sessionId } = event.params;
+          dispatch({
+            type: 'opened',
+            session: {
+              sessionId,
+              scheme,
+              isVisible: false,
+              App: lazy(() => microFrontendRuntime.importApp<AppModule>(`${appName}/App`)),
+            },
+          });
+          return;
+        }
+        case 'closeApp':
+          dispatch({ type: 'closed', sessionId: event.params.sessionId });
+          return;
+        case 'sessionVisibilityChanged':
+          dispatch({
+            type: 'visibilityChanged',
+            sessionId: event.params.sessionId,
+            isVisible: event.params.isVisible,
+          });
+          return;
+        default:
+          event satisfies never;
+      }
+    });
+
+    return () => subscription.remove();
+  }, []);
+
+  return (
+    <PortalProvider>
+      <View style={styles.container}>
+        {sessions.map((session) => (
+          <SessionRoot key={session.sessionId} initialProps={initialProps} session={session} />
+        ))}
+      </View>
+    </PortalProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/services/shared/src/types.ts
+++ b/services/shared/src/types.ts
@@ -1,5 +1,3 @@
-import type { RuntimeContext } from '@granite-js/plugin-micro-frontend/runtime';
-
 export interface GraniteGlobal {
   /**
    * @internal
@@ -11,10 +9,4 @@ export interface GraniteGlobal {
      */
     loadRemote: () => Promise<void>;
   };
-
-  /**
-   * @internal
-   * Micro frontend runtime
-   */
-  __MICRO_FRONTEND__: RuntimeContext;
 }

--- a/services/shared/src/utils/loadAppContent.ts
+++ b/services/shared/src/utils/loadAppContent.ts
@@ -1,3 +1,4 @@
+import type { InitialProps } from '@granite-js/react-native';
 import { BrickModule } from 'brick-module';
 import type { ComponentType } from 'react';
 import { getGlobal } from './getGlobal';
@@ -5,7 +6,7 @@ import { isMetro } from './isMetro';
 import { resolveAppContent } from './resolveAppContent';
 
 interface LoadResult {
-  default: ComponentType<any>;
+  default: ComponentType<InitialProps>;
 }
 
 const global = getGlobal();

--- a/services/shared/src/utils/resolveAppContent.ts
+++ b/services/shared/src/utils/resolveAppContent.ts
@@ -1,17 +1,30 @@
-import { getContainer, parseRemotePath, importRemoteModule } from '@granite-js/plugin-micro-frontend/runtime';
+import { getContainer } from '@granite-js/micro-frontend/runtime';
+import type { InitialProps } from '@granite-js/react-native';
 import type { ComponentType } from 'react';
 import { waitForCondition } from './waitForCondition';
 
-export async function resolveAppContent(remotePath: string): Promise<ComponentType<any>> {
-  const { remoteName } = parseRemotePath(remotePath);
+interface AppModule {
+  readonly default?: ComponentType<InitialProps>;
+}
+
+export async function resolveAppContent(remotePath: string): Promise<ComponentType<InitialProps>> {
+  const separatorIndex = remotePath.indexOf('/');
+  if (separatorIndex <= 0 || separatorIndex === remotePath.length - 1) {
+    throw new Error(`Invalid remote app request: ${remotePath}`);
+  }
+  const appName = remotePath.slice(0, separatorIndex);
+  const exposedModule = `./${remotePath.slice(separatorIndex + 1)}`;
 
   const isRemoteReady = () => {
-    return Boolean(getContainer(remoteName));
+    return getContainer(appName) != null;
   };
 
   const getAppComponent = () => {
-    const module = importRemoteModule(remotePath);
-    return module?.default || module;
+    const module = getContainer(appName)?.exposedModules[exposedModule] as AppModule | undefined;
+    if (module?.default == null) {
+      throw new Error(`Remote app module is unavailable: ${remotePath}`);
+    }
+    return module.default;
   };
 
   if (isRemoteReady()) {

--- a/services/shared/vitest.config.mts
+++ b/services/shared/vitest.config.mts
@@ -1,0 +1,11 @@
+import { reactNative } from '@granite-js/vitest';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  cacheDir: '.vitest',
+  plugins: [reactNative()],
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/services/showcase/granite.config.ts
+++ b/services/showcase/granite.config.ts
@@ -1,6 +1,6 @@
+import { microFrontend } from '@granite-js/micro-frontend/plugin';
 import { env } from '@granite-js/plugin-env';
 import { hermes } from '@granite-js/plugin-hermes';
-import { microFrontend } from '@granite-js/plugin-micro-frontend';
 import { router } from '@granite-js/plugin-router';
 import { sentry } from '@granite-js/plugin-sentry';
 import { defineConfig } from '@granite-js/react-native/config';
@@ -22,9 +22,8 @@ export default defineConfig({
     hermes(),
     sentry({ useClient: false }),
     microFrontend({
-      name: 'remoteApp',
       exposes: {
-        './AppContainer': './src/_app.tsx',
+        './App': './src/_app.tsx',
       },
       shared: [
         '@react-native-community/blur',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5337,6 +5337,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@granite-app/bare@workspace:services/bare":
+  version: 0.0.0-use.local
+  resolution: "@granite-app/bare@workspace:services/bare"
+  dependencies:
+    "@babel/core": "npm:7.28.5"
+    "@babel/runtime": "npm:7.18.9"
+    "@granite-js/forge-cli": "workspace:*"
+    "@granite-js/micro-frontend": "workspace:*"
+    "@granite-js/plugin-hermes": "workspace:*"
+    "@granite-js/react-native": "workspace:*"
+    "@react-native/babel-preset": "catalog:react-native"
+    "@types/node": "catalog:tools"
+    "@types/react": "catalog:react-native"
+    babel-preset-granite: "workspace:*"
+    react: "catalog:react-native"
+    react-native: "catalog:react-native"
+    typescript: "catalog:tools"
+  languageName: unknown
+  linkType: soft
+
 "@granite-app/counter@workspace:services/counter":
   version: 0.0.0-use.local
   resolution: "@granite-app/counter@workspace:services/counter"
@@ -5371,11 +5391,13 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:7.18.9"
     "@granite-js/forge-cli": "workspace:*"
+    "@granite-js/micro-frontend": "workspace:*"
     "@granite-js/mpack": "workspace:*"
     "@granite-js/native": "workspace:*"
     "@granite-js/plugin-hermes": "workspace:*"
-    "@granite-js/plugin-micro-frontend": "workspace:*"
+    "@granite-js/portal": "workspace:*"
     "@granite-js/react-native": "workspace:*"
+    "@granite-js/vitest": "workspace:*"
     "@react-native-async-storage/async-storage": "catalog:react-native"
     "@react-native-community/blur": "catalog:react-native"
     "@react-native/babel-preset": "catalog:react-native"
@@ -5396,6 +5418,7 @@ __metadata:
     react-native-svg: "catalog:react-native"
     react-native-webview: "catalog:react-native"
     typescript: "catalog:tools"
+    vitest: "npm:^4.0.12"
   languageName: unknown
   linkType: soft
 
@@ -5407,10 +5430,10 @@ __metadata:
     "@babel/runtime": "npm:7.18.9"
     "@biomejs/biome": "npm:^1.9.4"
     "@granite-js/forge-cli": "workspace:*"
+    "@granite-js/micro-frontend": "workspace:*"
     "@granite-js/native": "workspace:*"
     "@granite-js/plugin-env": "workspace:*"
     "@granite-js/plugin-hermes": "workspace:*"
-    "@granite-js/plugin-micro-frontend": "workspace:*"
     "@granite-js/plugin-router": "workspace:*"
     "@granite-js/plugin-sentry": "workspace:*"
     "@granite-js/react-native": "workspace:*"
@@ -5973,7 +5996,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@granite-js/portal@workspace:packages/portal":
+"@granite-js/portal@workspace:*, @granite-js/portal@workspace:packages/portal":
   version: 0.0.0-use.local
   resolution: "@granite-js/portal@workspace:packages/portal"
   dependencies:


### PR DESCRIPTION
## Summary

- add a one-runtime Shared host example using `@granite-js/micro-frontend`
- manage native app sessions with `useReducer` and mount each app through a named Portal host
- preload bundles without mounting UI, then reuse the evaluated app on `open`
- expose `./App` from Bare and Showcase and resolve them through a small allowlisted example bundle-loader adapter
- preserve the legacy Shared execution path when the micro-frontend runtime is disabled

## Runtime flow

1. Native emits `preload` or `open` with an app name and session information.
2. Shared calls `importApp('${appName}/App')`; the runtime composes adapter load and native evaluation once per app.
3. `open` mounts the imported component into the matching Portal host.
4. `close` unmounts the session, while `sessionVisibilityChanged` updates its visible state.

## Verification

- `yarn workspace @granite-js/micro-frontend typecheck`
- `yarn workspace @granite-js/micro-frontend test` (12 tests)
- `yarn workspace @granite-app/shared typecheck`
- `yarn workspace @granite-app/shared test` (5 tests)
- Bare, Showcase, and Shared iOS/Android builds
- `yarn build:all`

## Stack

- stacked on #342
- #342 is stacked on #338
