### PR TITLE
fix(react-native): unset iOS back press handler on cleanup instead of re-registering

### DIFF
--- a/.changeset/major-melons-help.md
+++ b/.changeset/major-melons-help.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+fix(react-native): unset iOS back press handler on cleanup instead of re-registering

--- a/packages/react-native/src/app/AppRoot.tsx
+++ b/packages/react-native/src/app/AppRoot.tsx
@@ -1,7 +1,12 @@
 import { SafeAreaProvider } from '@granite-js/native/react-native-safe-area-context';
 import type { ComponentType, PropsWithChildren } from 'react';
 import type { InitialProps } from '../initial-props';
-import { Router, type InternalRouterProps } from '../router';
+import {
+  Router,
+  type InternalRouterProps,
+  type SetIOSBackPressHandler,
+  type UnsetIOSBackPressHandler,
+} from '../router';
 import { BackEventProvider } from '../use-back-event';
 import { App } from './App';
 import type { GraniteProps } from './Granite';
@@ -16,7 +21,7 @@ interface AppRootProps extends GraniteProps {
   initialProps: InitialProps;
   initialScheme: string;
   setIosSwipeGestureEnabled?: ({ isEnabled }: { isEnabled: boolean }) => void;
-  setiOSBackPressHandler?: ({ handler }: { handler: () => void }) => Promise<void> | void;
+  setiOSBackPressHandler?: SetIOSBackPressHandler | UnsetIOSBackPressHandler;
   getInitialUrl: InternalRouterProps['getInitialUrl'];
 }
 

--- a/packages/react-native/src/app/AppRoot.tsx
+++ b/packages/react-native/src/app/AppRoot.tsx
@@ -1,12 +1,7 @@
 import { SafeAreaProvider } from '@granite-js/native/react-native-safe-area-context';
 import type { ComponentType, PropsWithChildren } from 'react';
 import type { InitialProps } from '../initial-props';
-import {
-  Router,
-  type InternalRouterProps,
-  type SetIOSBackPressHandler,
-  type UnsetIOSBackPressHandler,
-} from '../router';
+import { Router, type InternalRouterProps, type SetIOSBackPressHandler } from '../router';
 import { BackEventProvider } from '../use-back-event';
 import { App } from './App';
 import type { GraniteProps } from './Granite';
@@ -21,7 +16,7 @@ interface AppRootProps extends GraniteProps {
   initialProps: InitialProps;
   initialScheme: string;
   setIosSwipeGestureEnabled?: ({ isEnabled }: { isEnabled: boolean }) => void;
-  setiOSBackPressHandler?: SetIOSBackPressHandler | UnsetIOSBackPressHandler;
+  setiOSBackPressHandler?: SetIOSBackPressHandler;
   getInitialUrl: InternalRouterProps['getInitialUrl'];
 }
 

--- a/packages/react-native/src/app/Granite.tsx
+++ b/packages/react-native/src/app/Granite.tsx
@@ -2,7 +2,7 @@ import { ComponentType, type JSX, PropsWithChildren } from 'react';
 import { AppRegistry } from 'react-native';
 import { ENTRY_BUNDLE_NAME } from '../constants';
 import type { InitialProps } from '../initial-props';
-import type { RouterProps, RequireContext, SetIOSBackPressHandler, UnsetIOSBackPressHandler } from '../router';
+import type { RouterProps, RequireContext, SetIOSBackPressHandler } from '../router';
 import { AppRoot } from './AppRoot';
 import { HostAppRoot } from './HostAppRoot';
 import { getSchemeUri } from '../constant-bridges';
@@ -46,7 +46,7 @@ export interface GraniteProps {
    * that case the implementation must initialize the registered handler to `null`
    * (e.g. call `unsetBackPressHandler()`), not keep an empty function registered.
    */
-  setiOSBackPressHandler?: SetIOSBackPressHandler | UnsetIOSBackPressHandler;
+  setiOSBackPressHandler?: SetIOSBackPressHandler;
 
   /**
    * @description

--- a/packages/react-native/src/app/Granite.tsx
+++ b/packages/react-native/src/app/Granite.tsx
@@ -2,7 +2,7 @@ import { ComponentType, type JSX, PropsWithChildren } from 'react';
 import { AppRegistry } from 'react-native';
 import { ENTRY_BUNDLE_NAME } from '../constants';
 import type { InitialProps } from '../initial-props';
-import type { RouterProps, RequireContext } from '../router';
+import type { RouterProps, RequireContext, SetIOSBackPressHandler, UnsetIOSBackPressHandler } from '../router';
 import { AppRoot } from './AppRoot';
 import { HostAppRoot } from './HostAppRoot';
 import { getSchemeUri } from '../constant-bridges';
@@ -42,8 +42,11 @@ export interface GraniteProps {
   /**
    * @description
    * The function to register a handler that runs when the iOS swipe back gesture is detected.
+   * Called with no arguments when the handler should be unset — in that case the
+   * implementation must initialize the registered handler to `null`
+   * (e.g. call `unsetBackPressHandler()`), not keep an empty function registered.
    */
-  setiOSBackPressHandler?: ({ handler }: { handler: () => void }) => Promise<void> | void;
+  setiOSBackPressHandler?: SetIOSBackPressHandler | UnsetIOSBackPressHandler;
 
   /**
    * @description

--- a/packages/react-native/src/app/Granite.tsx
+++ b/packages/react-native/src/app/Granite.tsx
@@ -42,8 +42,8 @@ export interface GraniteProps {
   /**
    * @description
    * The function to register a handler that runs when the iOS swipe back gesture is detected.
-   * Called with no arguments when the handler should be unset — in that case the
-   * implementation must initialize the registered handler to `null`
+   * Called with empty params (`{}`, no `handler`) when the handler should be unset — in
+   * that case the implementation must initialize the registered handler to `null`
    * (e.g. call `unsetBackPressHandler()`), not keep an empty function registered.
    */
   setiOSBackPressHandler?: SetIOSBackPressHandler | UnsetIOSBackPressHandler;

--- a/packages/react-native/src/router/Router.tsx
+++ b/packages/react-native/src/router/Router.tsx
@@ -20,11 +20,7 @@ import {
 import { InitialProps } from '..';
 import { closeView } from '../native-modules';
 import { BackButton } from './components/BackButton';
-import {
-  CanGoBackGuard,
-  type SetIOSBackPressHandler,
-  type UnsetIOSBackPressHandler,
-} from './components/CanGoBackGuard';
+import { CanGoBackGuard, type SetIOSBackPressHandler } from './components/CanGoBackGuard';
 import { StackNavigator } from './components/StackNavigator';
 import { useInternalRouterBackHandler } from './components/useRouterBackHandler';
 import { useRouterControls, type RouterControlsConfig } from './hooks/useRouterControls';
@@ -69,7 +65,7 @@ export interface InternalRouterProps {
   initialProps: InitialProps;
   initialScheme: string;
   setIosSwipeGestureEnabled?: ({ isEnabled }: { isEnabled: boolean }) => Promise<void> | void;
-  setiOSBackPressHandler?: SetIOSBackPressHandler | UnsetIOSBackPressHandler;
+  setiOSBackPressHandler?: SetIOSBackPressHandler;
   getInitialUrl?: RouterControlsConfig['getInitialUrl'];
 }
 

--- a/packages/react-native/src/router/Router.tsx
+++ b/packages/react-native/src/router/Router.tsx
@@ -20,7 +20,11 @@ import {
 import { InitialProps } from '..';
 import { closeView } from '../native-modules';
 import { BackButton } from './components/BackButton';
-import { CanGoBackGuard } from './components/CanGoBackGuard';
+import {
+  CanGoBackGuard,
+  type SetIOSBackPressHandler,
+  type UnsetIOSBackPressHandler,
+} from './components/CanGoBackGuard';
 import { StackNavigator } from './components/StackNavigator';
 import { useInternalRouterBackHandler } from './components/useRouterBackHandler';
 import { useRouterControls, type RouterControlsConfig } from './hooks/useRouterControls';
@@ -65,7 +69,7 @@ export interface InternalRouterProps {
   initialProps: InitialProps;
   initialScheme: string;
   setIosSwipeGestureEnabled?: ({ isEnabled }: { isEnabled: boolean }) => Promise<void> | void;
-  setiOSBackPressHandler?: ({ handler }: { handler: () => void }) => Promise<void> | void;
+  setiOSBackPressHandler?: SetIOSBackPressHandler | UnsetIOSBackPressHandler;
   getInitialUrl?: RouterControlsConfig['getInitialUrl'];
 }
 

--- a/packages/react-native/src/router/components/CanGoBackGuard.spec.tsx
+++ b/packages/react-native/src/router/components/CanGoBackGuard.spec.tsx
@@ -73,7 +73,70 @@ describe('CanGoBackGuard', () => {
 
     unmount();
 
-    expect(setiOSBackPressHandler).toHaveBeenLastCalledWith({ handler: expect.any(Function) });
+    expect(setiOSBackPressHandler).toHaveBeenLastCalledWith();
+  });
+
+  it('unsets the iOS back press handler on unmount so the registered handler is initialized to null', () => {
+    mockPlatformOS('ios');
+
+    let registeredHandler: (() => void) | null = null;
+    const setiOSBackPressHandler = vi.fn((params?: { handler: () => void }) => {
+      registeredHandler = params?.handler ?? null;
+    });
+
+    const { unmount } = render(
+      <CanGoBackGuard
+        canGoBack={true}
+        hasBackEvent={true}
+        isInitialScreen={true}
+        setiOSBackPressHandler={setiOSBackPressHandler}
+      >
+        <div />
+      </CanGoBackGuard>
+    );
+
+    expect(registeredHandler).toEqual(expect.any(Function));
+
+    unmount();
+
+    expect(setiOSBackPressHandler).toHaveBeenLastCalledWith();
+    expect(registeredHandler).toBeNull();
+  });
+
+  it('unsets the iOS back press handler when back events no longer exist', () => {
+    mockPlatformOS('ios');
+
+    let registeredHandler: (() => void) | null = null;
+    const setiOSBackPressHandler = vi.fn((params?: { handler: () => void }) => {
+      registeredHandler = params?.handler ?? null;
+    });
+
+    const { rerender } = render(
+      <CanGoBackGuard
+        canGoBack={true}
+        hasBackEvent={true}
+        isInitialScreen={true}
+        setiOSBackPressHandler={setiOSBackPressHandler}
+      >
+        <div />
+      </CanGoBackGuard>
+    );
+
+    expect(registeredHandler).toEqual(expect.any(Function));
+
+    rerender(
+      <CanGoBackGuard
+        canGoBack={true}
+        hasBackEvent={false}
+        isInitialScreen={true}
+        setiOSBackPressHandler={setiOSBackPressHandler}
+      >
+        <div />
+      </CanGoBackGuard>
+    );
+
+    expect(setiOSBackPressHandler).toHaveBeenLastCalledWith();
+    expect(registeredHandler).toBeNull();
   });
 
   it('disables iOS swipe when the current state should block default back navigation', () => {

--- a/packages/react-native/src/router/components/CanGoBackGuard.spec.tsx
+++ b/packages/react-native/src/router/components/CanGoBackGuard.spec.tsx
@@ -73,15 +73,16 @@ describe('CanGoBackGuard', () => {
 
     unmount();
 
-    expect(setiOSBackPressHandler).toHaveBeenLastCalledWith();
+    expect(setiOSBackPressHandler).toHaveBeenLastCalledWith({});
   });
 
   it('unsets the iOS back press handler on unmount so the registered handler is initialized to null', () => {
     mockPlatformOS('ios');
 
     let registeredHandler: (() => void) | null = null;
-    const setiOSBackPressHandler = vi.fn((params?: { handler: () => void }) => {
-      registeredHandler = params?.handler ?? null;
+    // destructures params like legacy host implementations — must not crash on unset
+    const setiOSBackPressHandler = vi.fn(({ handler }: { handler?: () => void }) => {
+      registeredHandler = handler ?? null;
     });
 
     const { unmount } = render(
@@ -99,7 +100,7 @@ describe('CanGoBackGuard', () => {
 
     unmount();
 
-    expect(setiOSBackPressHandler).toHaveBeenLastCalledWith();
+    expect(setiOSBackPressHandler).toHaveBeenLastCalledWith({});
     expect(registeredHandler).toBeNull();
   });
 
@@ -107,8 +108,9 @@ describe('CanGoBackGuard', () => {
     mockPlatformOS('ios');
 
     let registeredHandler: (() => void) | null = null;
-    const setiOSBackPressHandler = vi.fn((params?: { handler: () => void }) => {
-      registeredHandler = params?.handler ?? null;
+    // destructures params like legacy host implementations — must not crash on unset
+    const setiOSBackPressHandler = vi.fn(({ handler }: { handler?: () => void }) => {
+      registeredHandler = handler ?? null;
     });
 
     const { rerender } = render(
@@ -135,7 +137,7 @@ describe('CanGoBackGuard', () => {
       </CanGoBackGuard>
     );
 
-    expect(setiOSBackPressHandler).toHaveBeenLastCalledWith();
+    expect(setiOSBackPressHandler).toHaveBeenLastCalledWith({});
     expect(registeredHandler).toBeNull();
   });
 

--- a/packages/react-native/src/router/components/CanGoBackGuard.tsx
+++ b/packages/react-native/src/router/components/CanGoBackGuard.tsx
@@ -5,18 +5,13 @@ import type { BackEvent } from '../../use-back-event';
 type SetIosSwipeGestureEnabled = ({ isEnabled }: { isEnabled: boolean }) => Promise<void> | void;
 
 /**
- * Registers the iOS back press handler.
+ * Registers the iOS back press handler. Called with empty params (`{}`, no
+ * `handler`) to unset — mirroring `unsetBackPressHandler()`, which calls
+ * `setBackPressHandler` with empty params. In that case implementations should
+ * initialize the registered handler to `null`, not keep an empty function
+ * registered.
  */
-export type SetIOSBackPressHandler = ({ handler }: { handler: () => void }) => Promise<void> | void;
-
-/**
- * Called with empty params (no `handler`) to unset the handler, mirroring
- * `unsetBackPressHandler()` which calls `setBackPressHandler` with empty
- * params. Implementations should initialize the registered handler to `null`,
- * not replace it with an empty function. Params are always an object so that
- * implementations destructuring `{ handler }` never crash.
- */
-export type UnsetIOSBackPressHandler = (params: { handler?: undefined }) => Promise<void> | void;
+export type SetIOSBackPressHandler = ({ handler }: { handler?: () => void }) => Promise<void> | void;
 
 export function CanGoBackGuard({
   children,
@@ -33,7 +28,7 @@ export function CanGoBackGuard({
   children: ReactNode;
   onBack?: (event: BackEvent) => void;
   setIosSwipeGestureEnabled?: SetIosSwipeGestureEnabled;
-  setiOSBackPressHandler?: SetIOSBackPressHandler | UnsetIOSBackPressHandler;
+  setiOSBackPressHandler?: SetIOSBackPressHandler;
 }) {
   useEffect(() => {
     if (Platform.OS !== 'ios') {
@@ -80,14 +75,14 @@ export function CanGoBackGuard({
       return;
     }
 
-    (setiOSBackPressHandler as SetIOSBackPressHandler)({
+    setiOSBackPressHandler({
       handler: () => {
         onBack?.({ source: 'iosSwipeGesture' });
       },
     });
 
     return () => {
-      (setiOSBackPressHandler as UnsetIOSBackPressHandler)({});
+      setiOSBackPressHandler?.({});
     };
   }, [hasBackEvent, onBack, setiOSBackPressHandler]);
 

--- a/packages/react-native/src/router/components/CanGoBackGuard.tsx
+++ b/packages/react-native/src/router/components/CanGoBackGuard.tsx
@@ -10,11 +10,13 @@ type SetIosSwipeGestureEnabled = ({ isEnabled }: { isEnabled: boolean }) => Prom
 export type SetIOSBackPressHandler = ({ handler }: { handler: () => void }) => Promise<void> | void;
 
 /**
- * Called with no arguments to unset the handler. Implementations should
- * initialize the registered handler to `null` (e.g. `unsetBackPressHandler()`),
- * not replace it with an empty function.
+ * Called with empty params (no `handler`) to unset the handler, mirroring
+ * `unsetBackPressHandler()` which calls `setBackPressHandler` with empty
+ * params. Implementations should initialize the registered handler to `null`,
+ * not replace it with an empty function. Params are always an object so that
+ * implementations destructuring `{ handler }` never crash.
  */
-export type UnsetIOSBackPressHandler = () => Promise<void> | void;
+export type UnsetIOSBackPressHandler = (params: { handler?: undefined }) => Promise<void> | void;
 
 export function CanGoBackGuard({
   children,
@@ -85,7 +87,7 @@ export function CanGoBackGuard({
     });
 
     return () => {
-      (setiOSBackPressHandler as UnsetIOSBackPressHandler)();
+      (setiOSBackPressHandler as UnsetIOSBackPressHandler)({});
     };
   }, [hasBackEvent, onBack, setiOSBackPressHandler]);
 

--- a/packages/react-native/src/router/components/CanGoBackGuard.tsx
+++ b/packages/react-native/src/router/components/CanGoBackGuard.tsx
@@ -3,7 +3,18 @@ import { BackHandler, Platform } from 'react-native';
 import type { BackEvent } from '../../use-back-event';
 
 type SetIosSwipeGestureEnabled = ({ isEnabled }: { isEnabled: boolean }) => Promise<void> | void;
-type SetIOSBackPressHandler = ({ handler }: { handler: () => void }) => Promise<void> | void;
+
+/**
+ * Registers the iOS back press handler.
+ */
+export type SetIOSBackPressHandler = ({ handler }: { handler: () => void }) => Promise<void> | void;
+
+/**
+ * Called with no arguments to unset the handler. Implementations should
+ * initialize the registered handler to `null` (e.g. `unsetBackPressHandler()`),
+ * not replace it with an empty function.
+ */
+export type UnsetIOSBackPressHandler = () => Promise<void> | void;
 
 export function CanGoBackGuard({
   children,
@@ -20,7 +31,7 @@ export function CanGoBackGuard({
   children: ReactNode;
   onBack?: (event: BackEvent) => void;
   setIosSwipeGestureEnabled?: SetIosSwipeGestureEnabled;
-  setiOSBackPressHandler?: SetIOSBackPressHandler;
+  setiOSBackPressHandler?: SetIOSBackPressHandler | UnsetIOSBackPressHandler;
 }) {
   useEffect(() => {
     if (Platform.OS !== 'ios') {
@@ -67,14 +78,14 @@ export function CanGoBackGuard({
       return;
     }
 
-    setiOSBackPressHandler({
+    (setiOSBackPressHandler as SetIOSBackPressHandler)({
       handler: () => {
         onBack?.({ source: 'iosSwipeGesture' });
       },
     });
 
     return () => {
-      setiOSBackPressHandler({ handler: () => {} });
+      (setiOSBackPressHandler as UnsetIOSBackPressHandler)();
     };
   }, [hasBackEvent, onBack, setiOSBackPressHandler]);
 

--- a/packages/react-native/src/router/index.ts
+++ b/packages/react-native/src/router/index.ts
@@ -2,4 +2,5 @@ export * from './Router';
 export { getRouteScreens, getScreenPathMapConfig, defaultParserParams } from './utils';
 export * from './types';
 export * from './components/BackButton';
+export type { SetIOSBackPressHandler, UnsetIOSBackPressHandler } from './components/CanGoBackGuard';
 export * from './components/useRouterBackHandler';

--- a/packages/react-native/src/router/index.ts
+++ b/packages/react-native/src/router/index.ts
@@ -2,5 +2,5 @@ export * from './Router';
 export { getRouteScreens, getScreenPathMapConfig, defaultParserParams } from './utils';
 export * from './types';
 export * from './components/BackButton';
-export type { SetIOSBackPressHandler, UnsetIOSBackPressHandler } from './components/CanGoBackGuard';
+export type { SetIOSBackPressHandler } from './components/CanGoBackGuard';
 export * from './components/useRouterBackHandler';


### PR DESCRIPTION
## Problem

`CanGoBackGuard` cleanup called `setiOSBackPressHandler` in a way that kept a handler registered on the native side. On the Toss app bridge, `unsetBackPressHandler()` internally calls `setBackPressHandler` with empty params to initialize the handler to `null` — keeping any handler registered (even an empty function) means:

- back navigation stays blocked after the screen using it unmounts
- iOS back-forward cache (bfCache) remains disabled

## Solution

- On effect cleanup, call `setiOSBackPressHandler()` **with no arguments** so the implementation can initialize the registered handler to `null` (e.g. by calling `unsetBackPressHandler()`).
- Introduce `SetIOSBackPressHandler | UnsetIOSBackPressHandler` as the public prop type (`Router`, `Granite`, `AppRoot`) and export both types, so implementers see the "no-argument call = unset" contract.

```ts
// implementation example
setiOSBackPressHandler={(params) =>
  params?.handler
    ? setBackPressHandler({ callback: params.handler })
    : unsetBackPressHandler()
}