### PR TITLE
feat(screen): add graniteHostDidStart to GraniteReactHost

### DIFF
--- a/.changeset/bold-snakes-laugh.md
+++ b/.changeset/bold-snakes-laugh.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/screen': patch
+---
+
+feat(screen): add graniteHostDidStart to GraniteReactHost

--- a/packages/granite-screen/ios/ReactNativeHosting/GraniteHostingHelper.swift
+++ b/packages/granite-screen/ios/ReactNativeHosting/GraniteHostingHelper.swift
@@ -40,6 +40,7 @@ public extension GraniteReactHost where Self: UIViewController {
             do {
                 let item = try await convertToGraniteItem(bundleSource: bundle)
                 let delegate = ReactNativeFactoryDelegate(url: item.hostURL)
+                delegate.reactHost = self  // self is GraniteReactHost
                 delegate.dependencyProvider = RCTAppDependencyProvider()
                 // Use GraniteNativeFactoryWrapper to enable module customization
                 let factory = GraniteNativeFactoryImpl(delegate: delegate)

--- a/packages/granite-screen/ios/ReactNativeHosting/GraniteNativeFactoryDelegate.h
+++ b/packages/granite-screen/ios/ReactNativeHosting/GraniteNativeFactoryDelegate.h
@@ -1,0 +1,24 @@
+//
+// GraniteNativeFactoryDelegate.h
+// GraniteScreen
+//
+// Base factory delegate that exposes the host start callback to Swift
+//
+
+#if __has_include(<React-RCTAppDelegate/RCTDefaultReactNativeFactoryDelegate.h>)
+#import <React-RCTAppDelegate/RCTDefaultReactNativeFactoryDelegate.h>
+#else
+#import <React_RCTAppDelegate/RCTDefaultReactNativeFactoryDelegate.h>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Base delegate that republishes `hostDidStart:`, which Swift cannot override
+@interface GraniteNativeFactoryDelegate : RCTDefaultReactNativeFactoryDelegate
+
+/// called right after the React Native instance is created, before the JS bundle is evaluated
+- (void)graniteHostDidStart;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/granite-screen/ios/ReactNativeHosting/GraniteNativeFactoryDelegate.m
+++ b/packages/granite-screen/ios/ReactNativeHosting/GraniteNativeFactoryDelegate.m
@@ -1,0 +1,29 @@
+//
+// GraniteNativeFactoryDelegate.m
+// GraniteScreen
+//
+// Base factory delegate that exposes the host start callback to Swift
+//
+
+#import "GraniteNativeFactoryDelegate.h"
+
+@class RCTHost;
+
+// `RCTReactNativeFactoryDelegate` adopts `RCTHostDelegate` only under
+// `__cplusplus`, so this selector is invisible here. Redeclaring it keeps the
+// file plain Objective-C.
+@interface RCTDefaultReactNativeFactoryDelegate (GraniteHostDidStart)
+- (void)hostDidStart:(RCTHost *)host;
+@end
+
+@implementation GraniteNativeFactoryDelegate
+
+- (void)hostDidStart:(RCTHost *)host {
+  [super hostDidStart:host];
+  [self graniteHostDidStart];
+}
+
+- (void)graniteHostDidStart {
+}
+
+@end

--- a/packages/granite-screen/ios/ReactNativeHosting/GraniteNativeFactoryDelegateImpl.swift
+++ b/packages/granite-screen/ios/ReactNativeHosting/GraniteNativeFactoryDelegateImpl.swift
@@ -8,8 +8,10 @@ import Foundation
 import React
 import React_RCTAppDelegate
 
-public class ReactNativeFactoryDelegate: RCTDefaultReactNativeFactoryDelegate {
+public class ReactNativeFactoryDelegate: GraniteNativeFactoryDelegate {
     private let url: URL
+
+    weak var reactHost: GraniteReactHost?
 
     public init(url: URL) {
         self.url = url
@@ -26,5 +28,9 @@ public class ReactNativeFactoryDelegate: RCTDefaultReactNativeFactoryDelegate {
 
     public override func bridgelessEnabled() -> Bool {
         return true
+    }
+
+    public override func graniteHostDidStart() -> Bool {
+        reactHost?.graniteHostDidStart()
     }
 }

--- a/packages/granite-screen/ios/ReactNativeHosting/GraniteReactHost.swift
+++ b/packages/granite-screen/ios/ReactNativeHosting/GraniteReactHost.swift
@@ -17,6 +17,9 @@ public protocol GraniteReactHost: AnyObject {
     /// Return nil to use the default bundle from app
     var bundleLoader: BundleLoadable { get }
     func graniteSetupDidStart()
+    /// Called right after the React Native instance is created, before the JS bundle is evaluated
+    /// Fires again the host is built, so a reload calls it once more
+    func graniteHostDidStart()
     func graniteSetupDidFinish()
     func graniteSetupDidError(didFailWith error: Error)
     /// Module instance creation (same as Objective-C)
@@ -29,6 +32,8 @@ public protocol GraniteReactHost: AnyObject {
 
 // Default implementation - returns nil
 extension GraniteReactHost {
+    public func graniteHostDidStart() {}  // Default does nothing
+
     public func getModuleInstance(from moduleClass: AnyClass) -> Any? {
         return nil  // Default returns nil
     }

--- a/packages/granite-screen/ios/ReactNativeHosting/GraniteScreen-Bridging-Header.h
+++ b/packages/granite-screen/ios/ReactNativeHosting/GraniteScreen-Bridging-Header.h
@@ -10,3 +10,4 @@
 #import <React/RCTRootView.h>
 #import <React/RCTBridgeDelegate.h>
 #import "GraniteDefaultModuleProvider.h"
+#import "GraniteNativeFactoryDelegate.h"


### PR DESCRIPTION
### Motivation

A host has no way to run code between "the React Native instance exists" and "the JS bundle is evaluated".

That window matters for anyone installing a `ReactMarker` hook: `RCTInstance` re-registers the marker slot in its initializer, so a hook installed earlier is wiped and has to be re-installed per instance.

ReactNative does expose the moment - `RCTHostDelegate.hostDidStart:`, called right after the instance is created. But `RCTReactNativeFactoryDelegate` adopts `RCTHostDelegate` only inside a `#if defined(__cplusplus)` block, so the selector never reaches Swift and a Swift subclass of `RCTDefaultReactNativeFactoryDelegate` has nothing to override.

### What this adds

- `GraniteReactHost.graniteHostDidStart()` : called right after the instance is created, before the JS bundle is evaluated. Fires again when the host is rebuilt, so a reload calls it once more
- `GraniteNativeFactoryDelegate` : an Objective-C base class that takes `hostDidStart:` and republishes it as a plain method Swift can override

### Notes

- Source compatible. The protocol requirement ships with an empty default implementation, so existing hosts keep compiling untouched
- The base class is plain Objective-C on purpose. Compiling it as Objective-C++ pull `<ReactCommon/RCTHost.h>` in through the header chain, which would add `React-RuntimeApple`, `ReactCommon` and `React-RCTFabric` to the podspec
- Calls `super`. The base implementation is a no-op right now, so this only matters if it ever gains a body
