### PR TITLE
fix(screen): drop the stray return type on graniteHostDidStart

### DIFF
--- a/.changeset/curly-hotels-throw.md
+++ b/.changeset/curly-hotels-throw.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/screen': patch
+---
+
+fix(screen): drop the stray return type on graniteHostDidStart

--- a/packages/granite-screen/ios/ReactNativeHosting/GraniteNativeFactoryDelegateImpl.swift
+++ b/packages/granite-screen/ios/ReactNativeHosting/GraniteNativeFactoryDelegateImpl.swift
@@ -30,7 +30,7 @@ public class ReactNativeFactoryDelegate: GraniteNativeFactoryDelegate {
         return true
     }
 
-    public override func graniteHostDidStart() -> Bool {
+    public override func graniteHostDidStart() {
         reactHost?.graniteHostDidStart()
     }
 }

--- a/packages/granite-screen/ios/ReactNativeHosting/GraniteReactHost.swift
+++ b/packages/granite-screen/ios/ReactNativeHosting/GraniteReactHost.swift
@@ -18,7 +18,7 @@ public protocol GraniteReactHost: AnyObject {
     var bundleLoader: BundleLoadable { get }
     func graniteSetupDidStart()
     /// Called right after the React Native instance is created, before the JS bundle is evaluated
-    /// Fires again the host is built, so a reload calls it once more
+    /// Fires again when the host is rebuilt, so a reload calls it once more
     func graniteHostDidStart()
     func graniteSetupDidFinish()
     func graniteSetupDidError(didFailWith error: Error)


### PR DESCRIPTION
## Problem
- `graniteHostDidStart()` has a stray `-> Bool` that slipped in during the merge of #349 
- The base class declares `- (void)graniteHostDidStart;`, so it does not compile in the consuming app

## Changes
- Remove the return type
- Fix doc comment wording