### PR TITLE
chore: republish micro-frontend v2

### DIFF
--- a/.changeset/tidy-mails-relax.md
+++ b/.changeset/tidy-mails-relax.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/micro-frontend': patch
+---
+
+Republish the micro-frontend package with normalized internal dependency versions.


### PR DESCRIPTION
## What

- add a patch changeset for `@granite-js/micro-frontend`
- let the v2 fixed release group produce 2.0.1 for every Granite package

## Why

`@granite-js/micro-frontend@2.0.0` was already present in npm with an unresolved `workspace:*` dependency, so the official v2 release skipped the immutable version. Publishing 2.0.1 through the normal Changesets/Yarn path normalizes internal dependency versions.

## Verification

- `yarn changeset status` resolves the fixed group from 2.0.0 to 2.0.1
- `yarn pack` manifest check resolves `@granite-js/utils` to 2.0.1 with no `workspace:` ranges