### PR TITLE
feat(react-native): export InitialPropsProvider

### DIFF
--- a/.changeset/tricky-donkeys-shave.md
+++ b/.changeset/tricky-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/react-native': patch
+---
+
+feat(react-native): export InitialPropsProvider

--- a/packages/react-native/src/app/context/InitialPropsContext.tsx
+++ b/packages/react-native/src/app/context/InitialPropsContext.tsx
@@ -3,6 +3,33 @@ import { InitialProps } from '../../initial-props';
 
 export const InitialPropsContext = createContext<InitialProps | null>(null);
 
+/**
+ * @public
+ * @name InitialPropsProvider
+ * @category Core
+ * @description Provides the initial data passed from the native platform (Android or iOS) to `useInitialProps` and `useInitialSearchParams`. `Granite.registerApp` already renders this provider, so you only need it when you register the root component yourself instead of going through the router.
+ * @param {InitialProps} initialProps - Initial data the native platform passed to the root component.
+ * @param {ReactNode | undefined} children - Child components that read the initial data.
+ * @returns {ReactElement} A React Provider component.
+ * @example
+ *
+ * ### Registering a root component without the router
+ *
+ * ```tsx
+ * import { AppRegistry } from 'react-native';
+ * import { InitialPropsProvider, type InitialProps } from '@granite-js/react-native';
+ *
+ * function App(initialProps: InitialProps) {
+ *   return (
+ *     <InitialPropsProvider initialProps={initialProps}>
+ *       <MyApp />
+ *     </InitialPropsProvider>
+ *   );
+ * }
+ *
+ * AppRegistry.registerComponent('my-app', () => App);
+ * ```
+ */
 export function InitialPropsProvider({ children, initialProps }: PropsWithChildren<{ initialProps: InitialProps }>) {
   return <InitialPropsContext.Provider value={initialProps}>{children}</InitialPropsContext.Provider>;
 }

--- a/packages/react-native/src/app/index.ts
+++ b/packages/react-native/src/app/index.ts
@@ -1,4 +1,4 @@
-export { useInitialProps } from './context/InitialPropsContext';
+export { InitialPropsProvider, useInitialProps } from './context/InitialPropsContext';
 export { useInitialSearchParams } from './context/useInitialSearchParams';
 export { Granite } from './Granite';
 export type { GraniteProps } from './Granite';

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,6 +1,6 @@
 import './types/global';
 
-export { Granite, useInitialSearchParams, useInitialProps } from './app';
+export { Granite, InitialPropsProvider, useInitialSearchParams, useInitialProps } from './app';
 export * from '@granite-js/style-utils';
 export {
   type GraniteImageSource,


### PR DESCRIPTION
## Problem

`useInitialProps` and `useInitialSearchParams` throw `InitialPropsContext not found` unless an `InitialPropsProvider` sits above them:

```ts
// packages/react-native/src/app/context/InitialPropsContext.tsx
export function useInitialProps<T extends InitialProps>() {
  const initialProps = useContext(InitialPropsContext);

  if (!initialProps) {
    throw new Error('InitialPropsContext not found');
  }
  ...
}
```

That provider is rendered in exactly one place — `AppRoot` — and `AppRoot` is reachable only through `Granite.registerApp`, which also brings the `Router`, a `NavigationContainer`, and file-based routing under `require.context`.

`Granite.registerHostApp` does not render it either (`HostAppRoot` only wraps `App`), and `InitialPropsProvider` is not exported from the package, so an app that registers its own root component cannot render it itself:

```tsx
import { AppRegistry } from 'react-native';
import type { InitialProps } from '@granite-js/react-native';

function App(initialProps: InitialProps) {
  return <MyApp />; // anything below that reads initial props throws
}

AppRegistry.registerComponent('my-app', () => App);
```

Our app is a single full-screen native container with no in-app navigation, so we deliberately do not use the router or a `NavigationContainer`. We do want the initial props the native platform hands to the root component, and so do libraries we depend on — the internal logging components call `useInitialSearchParams()` to read `referrer`, which makes them unusable in this setup.

Today the only workarounds are adopting the whole router just for the provider, or patching the package.

## Change

Export `InitialPropsProvider` from `@granite-js/react-native` and give it a doc comment in the same style as the other public providers. No behavior change — `AppRoot` keeps rendering it exactly as before, and apps that register their own root can now do:

```tsx
import { AppRegistry } from 'react-native';
import { InitialPropsProvider, type InitialProps } from '@granite-js/react-native';

function App(initialProps: InitialProps) {
  return (
    <InitialPropsProvider initialProps={initialProps}>
      <MyApp />
    </InitialPropsProvider>
  );
}

AppRegistry.registerComponent('my-app', () => App);
```

## Notes

- The reference page under `docs/reference/react-native/core/` is not included — happy to add it if you point me at how those pages are generated.
- `nx run @granite-js/react-native:typecheck` and `eslint` on the touched files pass.