### PR TITLE
fix(micro-frontend): detect iOS JSI runtime without NSProxy message dispatch

### DIFF
--- a/.changeset/quiet-rivers-listen.md
+++ b/.changeset/quiet-rivers-listen.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/micro-frontend': patch
+---
+
+fix(micro-frontend): detect iOS JSI runtime without sending respondsToSelector: through RCTBridgeProxy

--- a/packages/micro-frontend/ios/GraniteMicroFrontendRuntimeModule.mm
+++ b/packages/micro-frontend/ios/GraniteMicroFrontendRuntimeModule.mm
@@ -44,10 +44,9 @@ RCT_EXPORT_MODULE(GraniteMicroFrontendRuntime)
 
 - (facebook::jsi::Runtime *)jsRuntimeIfAvailable {
   RCTBridge *bridge = self.bridge;
-  // RCTBridgeProxy는 NSProxy라 respondsToSelector: 메시지가 forwardInvocation으로 흘러
-  // 반환 버퍼가 0으로 남는다 — 직접 구현된 runtime조차 항상 NO가 되어 모든 서비스
-  // evaluate가 RUNTIME_UNAVAILABLE로 죽는다. 메시지 디스패치를 타지 않는 ObjC 런타임
-  // C 함수로 실제 클래스의 셀렉터 구현 여부를 판정한다.
+  // RCTBridgeProxy is an NSProxy, so respondsToSelector: is forwarded and
+  // leaves the BOOL return buffer as NO even when runtime is implemented.
+  // Probe the real class without going through message dispatch.
   if (bridge == nil ||
       !class_respondsToSelector(object_getClass(bridge), @selector(runtime))) {
     return nullptr;

--- a/packages/micro-frontend/ios/GraniteMicroFrontendRuntimeModule.mm
+++ b/packages/micro-frontend/ios/GraniteMicroFrontendRuntimeModule.mm
@@ -2,6 +2,7 @@
 
 #import "GraniteMicroFrontendRuntimeHost+Internal.h"
 #import <React/RCTBridge.h>
+#import <objc/runtime.h>
 #import <React/RCTBridgeProxy+Cxx.h>
 #import <React-callinvoker/ReactCommon/CallInvoker.h>
 #import <jsi/jsi.h>
@@ -43,7 +44,12 @@ RCT_EXPORT_MODULE(GraniteMicroFrontendRuntime)
 
 - (facebook::jsi::Runtime *)jsRuntimeIfAvailable {
   RCTBridge *bridge = self.bridge;
-  if (bridge == nil || ![bridge respondsToSelector:@selector(runtime)]) {
+  // RCTBridgeProxy는 NSProxy라 respondsToSelector: 메시지가 forwardInvocation으로 흘러
+  // 반환 버퍼가 0으로 남는다 — 직접 구현된 runtime조차 항상 NO가 되어 모든 서비스
+  // evaluate가 RUNTIME_UNAVAILABLE로 죽는다. 메시지 디스패치를 타지 않는 ObjC 런타임
+  // C 함수로 실제 클래스의 셀렉터 구현 여부를 판정한다.
+  if (bridge == nil ||
+      !class_respondsToSelector(object_getClass(bridge), @selector(runtime))) {
     return nullptr;
   }
   return reinterpret_cast<facebook::jsi::Runtime *>(bridge.runtime);


### PR DESCRIPTION
## Problem
- `RCTBridgeProxy` is an `NSProxy`, so `[bridge respondsToSelector:@selector(runtime)]` is forwarded through `forwardInvocation:`
- The BOOL return buffer stays `NO` even when `runtime` is actually implemented
- Every service `evaluate` then fails with `RUNTIME_UNAVAILABLE`

## Changes
- Import `<objc/runtime.h>` and probe the real class with `class_respondsToSelector(object_getClass(bridge), @selector(runtime))` so the check does not go through message dispatch
- Add a patch changeset for `@granite-js/micro-frontend`

## Test plan
- [ ] On iOS New Architecture / `RCTBridgeProxy`, load a micro-frontend service and confirm `evaluateScript` no longer rejects with `RUNTIME_UNAVAILABLE`
- [ ] Confirm `jsRuntimeIfAvailable` still returns `nullptr` when the bridge is `nil` or the class does not implement `runtime`