### PR TITLE
fix(micro-frontend): reuse native view registrations across bundles

### DIFF
--- a/.changeset/quiet-webviews-share.md
+++ b/.changeset/quiet-webviews-share.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/micro-frontend': patch
+---
+
+Reuse host native component registrations when remote bundles evaluate matching native wrappers.

--- a/packages/micro-frontend/README.md
+++ b/packages/micro-frontend/README.md
@@ -193,6 +193,11 @@ adapter.loadBundle({ appName: 'cart' })
 Concurrent preload/import calls for one app share an evaluation. A successful
 evaluation remains cached for the lifetime of the JavaScript runtime. Failed
 evaluation removes the partial container so a later request can retry.
+Before evaluating a remote, the runtime also adapts the shared React Native
+component registry so a native view wrapper already evaluated by the host can
+be evaluated again by a separate remote bundle. The canonical host registration
+is reused only for React Native's exact duplicate-view invariant; other registry
+errors continue to fail the remote evaluation.
 Native `preloadApp` events invoke `preloadApp()` inside the runtime and are not
 forwarded to session listeners. `onPreloadError` is optional and lets the host
 route best-effort native preload failures to its observability provider.

--- a/packages/micro-frontend/src/runtime/createMicroFrontendRuntime.spec.ts
+++ b/packages/micro-frontend/src/runtime/createMicroFrontendRuntime.spec.ts
@@ -11,8 +11,11 @@ import {
   type NativeMicroFrontendRuntime,
   type NativeMicroFrontendRuntimeEvent,
 } from './createMicroFrontendRuntime';
+import { getMicroFrontendGlobalContext } from './globalContext';
 import { parseNativeRuntimeEvent } from './parseNativeRuntimeEvent';
 import { createContainer, exposeModule, microFrontendModuleRegistry } from './registry';
+
+const NATIVE_COMPONENT_REGISTRY_MODULE = 'react-native/Libraries/NativeComponent/NativeComponentRegistry';
 
 interface AppModule {
   readonly default: () => string;
@@ -88,6 +91,40 @@ describe('createMicroFrontendRuntimeWithDependencies', () => {
     expect(fixture.nativeRuntime.evaluateScript).toHaveBeenCalledWith({
       filePath: '/bundles/cart.hbc',
     });
+  });
+
+  it('reuses a native view registered by the host when a remote bundle evaluates its wrapper', async () => {
+    // Given
+    const fixture = createRuntimeFixture();
+    const registeredViews = new Set<string>();
+    const nativeComponentRegistry = {
+      get(name: string) {
+        if (registeredViews.has(name)) {
+          throw new Error(`Tried to register two views with the same name ${name}`);
+        }
+        registeredViews.add(name);
+        return name;
+      },
+    };
+    nativeComponentRegistry.get('TossServiceWebView');
+    getMicroFrontendGlobalContext().__SHARED__[NATIVE_COMPONENT_REGISTRY_MODULE] = {
+      get: () => nativeComponentRegistry,
+      loaded: true,
+    };
+    vi.mocked(fixture.nativeRuntime.evaluateScript).mockImplementationOnce(async () => {
+      const remoteRegistry = getMicroFrontendGlobalContext().__SHARED__[NATIVE_COMPONENT_REGISTRY_MODULE]?.get();
+      const remoteGet =
+        typeof remoteRegistry === 'object' && remoteRegistry != null ? Reflect.get(remoteRegistry, 'get') : undefined;
+      if (typeof remoteGet !== 'function') {
+        throw new Error('NativeComponentRegistry.get is unavailable');
+      }
+      Reflect.apply(remoteGet, remoteRegistry, ['TossServiceWebView', () => ({})]);
+      createContainer('visit-mission');
+    });
+
+    // When / Then
+    await expect(fixture.runtime.preloadApp('visit-mission')).resolves.toBeUndefined();
+    expect(registeredViews).toEqual(new Set(['TossServiceWebView']));
   });
 
   it('removes a failed evaluation so the next preload can retry', async () => {

--- a/packages/micro-frontend/src/runtime/createMicroFrontendRuntime.ts
+++ b/packages/micro-frontend/src/runtime/createMicroFrontendRuntime.ts
@@ -7,6 +7,7 @@ import type {
 } from '../types';
 import { AppContainerNotFoundError, InvalidAppNameError } from './errors';
 import { getMicroFrontendGlobalContext } from './globalContext';
+import { installNativeComponentRegistryCompatibility } from './nativeComponentRegistryCompatibility';
 import { parseAppRequest } from './parseAppRequest';
 
 export interface NativeMicroFrontendRuntimeEvent {
@@ -71,6 +72,7 @@ export function createMicroFrontendRuntimeWithDependencies(
 
   function evaluateScript(filePath: string): Promise<void> {
     getMicroFrontendGlobalContext();
+    installNativeComponentRegistryCompatibility();
     return dependencies.nativeRuntime.evaluateScript({ filePath });
   }
 

--- a/packages/micro-frontend/src/runtime/nativeComponentRegistryCompatibility.spec.ts
+++ b/packages/micro-frontend/src/runtime/nativeComponentRegistryCompatibility.spec.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getMicroFrontendGlobalContext } from './globalContext';
+import { installNativeComponentRegistryCompatibility } from './nativeComponentRegistryCompatibility';
+
+const NATIVE_COMPONENT_REGISTRY_MODULE = 'react-native/Libraries/NativeComponent/NativeComponentRegistry';
+
+describe('installNativeComponentRegistryCompatibility', () => {
+  beforeEach(() => {
+    Reflect.deleteProperty(globalThis, '__MICRO_FRONTEND__');
+  });
+
+  it('preserves native component registry errors other than duplicate registration', () => {
+    // Given
+    const registryError = new Error('Native component view config is unavailable');
+    const nativeComponentRegistry = {
+      get() {
+        throw registryError;
+      },
+    };
+    getMicroFrontendGlobalContext().__SHARED__[NATIVE_COMPONENT_REGISTRY_MODULE] = {
+      get: () => nativeComponentRegistry,
+      loaded: true,
+    };
+    installNativeComponentRegistryCompatibility();
+    const remoteRegistry = getMicroFrontendGlobalContext().__SHARED__[NATIVE_COMPONENT_REGISTRY_MODULE]?.get();
+    const remoteGet =
+      typeof remoteRegistry === 'object' && remoteRegistry != null ? Reflect.get(remoteRegistry, 'get') : undefined;
+    if (typeof remoteGet !== 'function') {
+      throw new Error('NativeComponentRegistry.get is unavailable');
+    }
+
+    // When
+    const getMissingNativeView = () => Reflect.apply(remoteGet, remoteRegistry, ['MissingNativeView', () => ({})]);
+
+    // Then
+    expect(getMissingNativeView).toThrow(registryError);
+  });
+});

--- a/packages/micro-frontend/src/runtime/nativeComponentRegistryCompatibility.ts
+++ b/packages/micro-frontend/src/runtime/nativeComponentRegistryCompatibility.ts
@@ -1,0 +1,60 @@
+import { getMicroFrontendGlobalContext } from './globalContext';
+
+const NATIVE_COMPONENT_REGISTRY_MODULE = 'react-native/Libraries/NativeComponent/NativeComponentRegistry';
+const COMPATIBILITY_MARKER = Symbol.for('granite.microFrontend.nativeComponentRegistryCompatibility');
+
+export function installNativeComponentRegistryCompatibility(): void {
+  const sharedModules = getMicroFrontendGlobalContext().__SHARED__;
+  const sharedEntry = sharedModules[NATIVE_COMPONENT_REGISTRY_MODULE];
+  if (sharedEntry == null || Reflect.get(sharedEntry, COMPATIBILITY_MARKER) === true) {
+    return;
+  }
+
+  const nativeComponentRegistry = sharedEntry.get();
+  if (!isNativeComponentRegistry(nativeComponentRegistry)) {
+    return;
+  }
+
+  const compatibleRegistry = new Proxy(nativeComponentRegistry, {
+    get(target, property, receiver) {
+      if (property !== 'get') {
+        return Reflect.get(target, property, receiver);
+      }
+
+      return (...args: readonly unknown[]) => {
+        try {
+          return Reflect.apply(target.get, target, args);
+        } catch (error) {
+          const componentName = args[0];
+          if (typeof componentName === 'string' && isDuplicateNativeViewRegistration(error, componentName)) {
+            return componentName;
+          }
+          throw error;
+        }
+      };
+    },
+  });
+  const compatibleEntry = {
+    get: () => compatibleRegistry,
+    loaded: sharedEntry.loaded,
+  };
+  Reflect.defineProperty(compatibleEntry, COMPATIBILITY_MARKER, { value: true });
+  sharedModules[NATIVE_COMPONENT_REGISTRY_MODULE] = compatibleEntry;
+}
+
+function isNativeComponentRegistry(
+  value: unknown
+): value is { readonly get: (...args: readonly unknown[]) => unknown } {
+  return typeof value === 'object' && value != null && typeof Reflect.get(value, 'get') === 'function';
+}
+
+function isDuplicateNativeViewRegistration(error: unknown, componentName: string): boolean {
+  if (typeof error !== 'object' || error == null) {
+    return false;
+  }
+
+  const message = Reflect.get(error, 'message');
+  return (
+    typeof message === 'string' && message.endsWith(`Tried to register two views with the same name ${componentName}`)
+  );
+}


### PR DESCRIPTION
## Summary

- adapt the host-shared React Native component registry before remote evaluation
- reuse an exact duplicate native view registration produced by separate bundle module caches
- preserve every other native component registry error

## Why

A retained React Native runtime can evaluate a native component wrapper once in the host bundle and again in a separately cached remote bundle. React Native rejects the second wrapper evaluation even though both bundles resolve the same host-shared registry.

## Test

- `yarn workspace @granite-js/micro-frontend test` (149 tests)
- `yarn workspace @granite-js/micro-frontend typecheck`
- `yarn workspace @granite-js/micro-frontend build`
- targeted ESLint and Prettier checks
- installed the pkg.pr.new preview in the frontend-mobile Shared consumer
- deployed RN 0.84 Android/iOS Shared bundles with 0 errors and 0 warnings
- reproduced the original sequential Android navigation before the fix, then verified the target screen renders and the duplicate-view invariant is absent with the preview