### PR TITLE
feat(micro-frontend): expose container runtime source URL

### DIFF
--- a/.changeset/clean-runtime-source.md
+++ b/.changeset/clean-runtime-source.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/micro-frontend': minor
+---
+
+Expose each evaluated app container's source URL through `AppContainer.runtime.sourceURL`, resolve the current container with `getAppName()`, and exact-match externally captured source URLs with `findAppNameBySourceURL()`.

--- a/packages/micro-frontend/README.md
+++ b/packages/micro-frontend/README.md
@@ -131,6 +131,15 @@ The durable owner is `global.__MICRO_FRONTEND__` with exactly this shape:
 - A current container registration creates paired legacy/current views for the
   same app name. The pair is transparent across separately evaluated bundles:
   it is one remote-owned registration, not two independently owned copies.
+- A current container exposes the evaluated bundle source through
+  `runtime.sourceURL`. The generated prelude captures it from the bundle's
+  evaluation stack once when registering the container. Legacy container
+  adapters omit `runtime` until a compatible bundle is evaluated.
+- `getAppName()` resolves the current bundle's structured source URL against
+  the container registry. A host call returns the host container name, while a
+  remote call returns that remote's name without reading a last-evaluated
+  global value. `findAppNameBySourceURL(sourceURL)` exposes the same exact
+  registry lookup for runtimes that already provide a structured source URL.
 - The dispose callback registry and registrar live on the same canonical
   context as non-enumerable properties. They are reused across separately
   evaluated bundles without changing the three-key enumerable registry shape.

--- a/packages/micro-frontend/src/index.ts
+++ b/packages/micro-frontend/src/index.ts
@@ -2,6 +2,7 @@ export { createMicroFrontendRuntime } from './createMicroFrontendRuntime';
 export type { CreateMicroFrontendRuntimeOptions } from './createMicroFrontendRuntime';
 export { createRoute } from './createRoute';
 export type { MicroFrontendRouteOptions } from './createRoute';
+export { findAppNameBySourceURL, getAppName } from './runtime/getAppName';
 export type { PendingHostComponentController, PendingHostComponentProps } from './host/PendingHostComponent';
 export {
   PendingHostComponent,
@@ -36,7 +37,12 @@ export {
 export type { MicroFrontendSession, MicroFrontendSessionProviderProps } from './session/MicroFrontendSessionContext';
 export { useMicroFrontendSessions } from './session/useMicroFrontendSessions';
 export type { MicroFrontendSessionState } from './session/useMicroFrontendSessions';
-export type { AppDisposeCallback, MicroFrontendRuntimeContext } from './runtime/registry';
+export type {
+  AppContainer,
+  AppContainerRuntime,
+  AppDisposeCallback,
+  MicroFrontendRuntimeContext,
+} from './runtime/registry';
 export { default as Portal } from './specs/PortalViewNativeComponent';
 export type {
   AppRequest,

--- a/packages/micro-frontend/src/plugin/prelude.spec.ts
+++ b/packages/micro-frontend/src/plugin/prelude.spec.ts
@@ -122,7 +122,8 @@ describe('getPreludeConfig', () => {
         'exposeModule(__container, "./App", exposedValue);',
         'registerShared("react", sharedValue);',
       ].join('\n'),
-      { exposedValue, global: globalObject, sharedValue: { version: '19' } }
+      { exposedValue, global: globalObject, sharedValue: { version: '19' } },
+      { filename: 'https://cdn.example.com/remote-app.hbc' }
     );
     const context = Reflect.get(globalObject, '__MICRO_FRONTEND__');
     const instances = Reflect.get(context, '__INSTANCES__');
@@ -133,6 +134,9 @@ describe('getPreludeConfig', () => {
     // Then
     expect(Object.keys(context)).toEqual(['__INSTANCES__', '__SHARED__', '__CONTAINERS__']);
     expect(Reflect.get(modernContainer, 'appName')).toBe('remote-app');
+    expect(Reflect.get(Reflect.get(modernContainer, 'runtime'), 'sourceURL')).toBe(
+      'https://cdn.example.com/remote-app.hbc'
+    );
     expect(Reflect.get(Reflect.get(modernContainer, 'exposedModules'), './App')).toBe(exposedValue);
     expect(Reflect.get(legacyContainer, 'name')).toBe('remote-app');
     const legacyModule = Reflect.get(Reflect.get(legacyContainer, 'exposeMap'), 'App');

--- a/packages/micro-frontend/src/plugin/prelude.ts
+++ b/packages/micro-frontend/src/plugin/prelude.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { globalContextScript } from './globalContextScript';
 import type { MicroFrontendPluginOptions } from './types';
 import { CONTAINER_PAIRING_KEY } from '../runtime/containerPairing';
+import { captureStackFrames, resolveCurrentSourceURL } from '../runtime/runtimeSourceURL';
 
 export interface MicroFrontendPreludeConfig {
   readonly banner: string;
@@ -28,6 +29,8 @@ export function getPreludeConfig(options: MicroFrontendPluginOptions, appName?: 
   });
   const containerConfig = JSON.stringify({ shared: options.shared });
   const containerName = appName == null ? 'global.__granite.app.name' : JSON.stringify(appName);
+  const captureFrames = captureStackFrames.toString();
+  const resolveSourceURL = resolveCurrentSourceURL.toString();
 
   return {
     banner: [
@@ -91,7 +94,9 @@ export function getPreludeConfig(options: MicroFrontendPluginOptions, appName?: 
       '  if (!Object.isExtensible(containers) || !Object.isExtensible(instances)) {',
       '    throw new Error("Cannot establish the micro-frontend global context: registry-is-not-extensible");',
       '  }',
-      '  const modernContainer = { appName, config, exposedModules: {} };',
+      `  const stackFrames = (${captureFrames})();`,
+      `  const sourceURL = (${resolveSourceURL})(stackFrames);`,
+      '  const modernContainer = { appName, config, exposedModules: {}, runtime: { sourceURL } };',
       '  const legacyContainer = { name: appName, config, exposeMap: {} };',
       '  try {',
       '    if (!Reflect.defineProperty(instances, appName, {',

--- a/packages/micro-frontend/src/plugin/preludeParity.spec.ts
+++ b/packages/micro-frontend/src/plugin/preludeParity.spec.ts
@@ -323,7 +323,7 @@ describe('generated-prelude runtime ownership', () => {
     expect(Object.getOwnPropertySymbols(originalLegacy)).toEqual([]);
   });
 
-  it('keeps generated pairing metadata out of public enumerable shapes', () => {
+  it('keeps pairing metadata private while exposing the runtime sourceURL', () => {
     // Given
     const config = getPreludeConfig({}, 'generated-shaped-app');
     vm.runInNewContext(config.banner + '\n' + config.preludeScript, { global: globalThis });
@@ -344,8 +344,9 @@ describe('generated-prelude runtime ownership', () => {
 
     // Then
     expect(shapes).toEqual({
-      modernJson: '{"appName":"generated-shaped-app","config":{},"exposedModules":{}}',
-      modernKeys: ['appName', 'config', 'exposedModules'],
+      modernJson:
+        '{"appName":"generated-shaped-app","config":{},"exposedModules":{},"runtime":{"sourceURL":"evalmachine.<anonymous>"}}',
+      modernKeys: ['appName', 'config', 'exposedModules', 'runtime'],
       legacyJson: '{"name":"generated-shaped-app","config":{},"exposeMap":{}}',
       legacyKeys: ['name', 'config', 'exposeMap'],
     });

--- a/packages/micro-frontend/src/runtime/containerRegistry.ts
+++ b/packages/micro-frontend/src/runtime/containerRegistry.ts
@@ -14,10 +14,12 @@ import {
 import { AppContainerAlreadyRegisteredError } from './errors';
 import { getMicroFrontendGlobalContext, MicroFrontendGlobalContextCompatibilityError } from './globalContext';
 import type { AppContainer, AppContainerConfig } from './registry';
+import { captureStackFrames, resolveCurrentSourceURL } from './runtimeSourceURL';
 
 export { exposeContainerModule as exposeModule } from './containerModuleExposure';
 
 export function createContainer(appName: string, config: AppContainerConfig = {}): AppContainer {
+  const sourceURL = resolveCurrentSourceURL(captureStackFrames());
   const context = getMicroFrontendGlobalContext();
   const canonicalValue: unknown = Reflect.get(context.__CONTAINERS__, appName);
   const legacyIndex: unknown = Reflect.get(context.__INSTANCES__, appName);
@@ -28,7 +30,12 @@ export function createContainer(appName: string, config: AppContainerConfig = {}
     throw new MicroFrontendGlobalContextCompatibilityError('registry-is-not-extensible');
   }
 
-  const modernContainer: AppContainer = { appName, config, exposedModules: {} };
+  const modernContainer: AppContainer = {
+    appName,
+    config,
+    exposedModules: {},
+    runtime: { sourceURL },
+  };
   const legacyContainer: LegacyAppContainer = { name: appName, config, exposeMap: {} };
   const containerIndex = context.__INSTANCES__.length;
 
@@ -222,11 +229,13 @@ function normalizeLegacyModule(exposedModule: string): string {
 }
 
 function isAppContainer(value: unknown): value is AppContainer {
+  const runtime: unknown = isObjectRecord(value) ? Reflect.get(value, 'runtime') : null;
   return (
     isObjectRecord(value) &&
     typeof Reflect.get(value, 'appName') === 'string' &&
     isAppContainerConfig(Reflect.get(value, 'config')) &&
-    isObjectRecord(Reflect.get(value, 'exposedModules'))
+    isObjectRecord(Reflect.get(value, 'exposedModules')) &&
+    (runtime == null || (isObjectRecord(runtime) && typeof Reflect.get(runtime, 'sourceURL') === 'string'))
   );
 }
 

--- a/packages/micro-frontend/src/runtime/getAppName.spec.ts
+++ b/packages/micro-frontend/src/runtime/getAppName.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAppNameBySourceURL, resolveAppNameFromStackFrames } from './getAppName';
+import type { AppContainer } from './registry';
+import type { RuntimeStackFrame } from './runtimeSourceURL';
+
+function createContainer(appName: string, sourceURL: string): AppContainer {
+  return { appName, config: {}, exposedModules: {}, runtime: { sourceURL } };
+}
+
+describe('resolveAppNameFromStack', () => {
+  it('resolves the first caller container', () => {
+    const frames: RuntimeStackFrame[] = [
+      { sourceURL: 'https://cdn.example.com/remote-app.hbc' },
+      { sourceURL: 'file:///host-app.hbc' },
+    ];
+    const containers = {
+      host: createContainer('host-app', 'file:///host-app.hbc'),
+      remote: createContainer('remote-app', 'https://cdn.example.com/remote-app.hbc'),
+    };
+
+    expect(resolveAppNameFromStackFrames(frames, containers)).toBe('remote-app');
+  });
+
+  it('returns the host app name when called from the host bundle', () => {
+    const frames: RuntimeStackFrame[] = [{ sourceURL: 'file:///host-app.hbc' }];
+    const containers = { host: createContainer('host-app', 'file:///host-app.hbc') };
+
+    expect(resolveAppNameFromStackFrames(frames, containers)).toBe('host-app');
+  });
+
+  it('throws when no caller frame matches a registered container', () => {
+    const frames: RuntimeStackFrame[] = [{ sourceURL: 'file:///unknown.hbc' }];
+    const containers = { host: createContainer('host-app', 'file:///host-app.hbc') };
+
+    expect(() => resolveAppNameFromStackFrames(frames, containers)).toThrow('app name');
+  });
+});
+
+describe('resolveAppNameBySourceURL', () => {
+  it('returns the app name for an exact sourceURL match', () => {
+    const containers = { remote: createContainer('remote-app', 'https://cdn.example.com/remote-app.hbc') };
+
+    expect(resolveAppNameBySourceURL('https://cdn.example.com/remote-app.hbc', containers)).toBe('remote-app');
+  });
+
+  it('returns null for an unknown sourceURL', () => {
+    const containers = { host: createContainer('host-app', 'file:///host-app.hbc') };
+
+    expect(resolveAppNameBySourceURL('file:///unknown.hbc', containers)).toBeNull();
+  });
+
+  it('returns null when a sourceURL belongs to different apps', () => {
+    const containers = {
+      first: createContainer('first-app', 'file:///same.hbc'),
+      second: createContainer('second-app', 'file:///same.hbc'),
+    };
+
+    expect(resolveAppNameBySourceURL('file:///same.hbc', containers)).toBeNull();
+  });
+});

--- a/packages/micro-frontend/src/runtime/getAppName.ts
+++ b/packages/micro-frontend/src/runtime/getAppName.ts
@@ -1,0 +1,46 @@
+import { getMicroFrontendRuntimeContext, type AppContainer } from './registry';
+import { captureStackFrames, resolveCurrentSourceURL, type RuntimeStackFrame } from './runtimeSourceURL';
+
+export function resolveAppNameBySourceURL(
+  sourceURL: string,
+  containers: Readonly<Record<string, AppContainer>>
+): string | null {
+  let resolvedAppName: string | null = null;
+  for (const container of Object.values(containers)) {
+    if (container.runtime?.sourceURL !== sourceURL) {
+      continue;
+    }
+    if (resolvedAppName != null && resolvedAppName !== container.appName) {
+      return null;
+    }
+    resolvedAppName = container.appName;
+  }
+  return resolvedAppName;
+}
+
+export function findAppNameBySourceURL(sourceURL: string): string | null {
+  return resolveAppNameBySourceURL(sourceURL, getMicroFrontendRuntimeContext().containers);
+}
+
+export function resolveAppNameFromStackFrames(
+  frames: readonly RuntimeStackFrame[],
+  containers: Readonly<Record<string, AppContainer>>
+): string {
+  const sourceURL = resolveCurrentSourceURL(frames);
+  const appName = resolveAppNameBySourceURL(sourceURL, containers);
+  if (appName != null) {
+    return appName;
+  }
+
+  throw new Error('Cannot resolve the current micro-frontend app name');
+}
+
+export function getAppName(): string {
+  const sourceURL = resolveCurrentSourceURL(captureStackFrames());
+  const appName = findAppNameBySourceURL(sourceURL);
+  if (appName != null) {
+    return appName;
+  }
+
+  throw new Error('Cannot resolve the current micro-frontend app name');
+}

--- a/packages/micro-frontend/src/runtime/registry.ts
+++ b/packages/micro-frontend/src/runtime/registry.ts
@@ -16,10 +16,15 @@ export interface AppContainerConfig {
   readonly shared?: SharedConfig;
 }
 
+export interface AppContainerRuntime {
+  readonly sourceURL: string;
+}
+
 export interface AppContainer {
   readonly appName: string;
   readonly config: AppContainerConfig;
   readonly exposedModules: Record<string, unknown>;
+  readonly runtime?: AppContainerRuntime;
 }
 
 export type AppDisposeCallback = () => void | Promise<void>;

--- a/packages/micro-frontend/src/runtime/runtimeSourceURL.spec.ts
+++ b/packages/micro-frontend/src/runtime/runtimeSourceURL.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { captureStackFrames, resolveCurrentSourceURL, type RuntimeStackFrame } from './runtimeSourceURL';
+
+describe('captureStackFrames', () => {
+  it('returns structured CallSite file names without parsing stack strings', () => {
+    expect(captureStackFrames().some(frame => frame.sourceURL === __filename)).toBe(true);
+  });
+
+  it('restores an existing prepareStackTrace hook', () => {
+    const previous = Reflect.getOwnPropertyDescriptor(Error, 'prepareStackTrace');
+    const prepareStackTrace = () => 'custom-stack';
+    Reflect.defineProperty(Error, 'prepareStackTrace', { configurable: true, value: prepareStackTrace });
+
+    try {
+      captureStackFrames();
+      expect(Reflect.get(Error, 'prepareStackTrace')).toBe(prepareStackTrace);
+    } finally {
+      if (previous == null) {
+        Reflect.deleteProperty(Error, 'prepareStackTrace');
+      } else {
+        Reflect.defineProperty(Error, 'prepareStackTrace', previous);
+      }
+    }
+  });
+
+  it('resolves the first structured caller sourceURL', () => {
+    const frames: RuntimeStackFrame[] = [
+      { sourceURL: null },
+      { sourceURL: 'file:///caller.js' },
+    ];
+
+    expect(resolveCurrentSourceURL(frames)).toBe('file:///caller.js');
+  });
+});

--- a/packages/micro-frontend/src/runtime/runtimeSourceURL.ts
+++ b/packages/micro-frontend/src/runtime/runtimeSourceURL.ts
@@ -1,0 +1,48 @@
+export interface RuntimeStackFrame {
+  readonly sourceURL: string | null;
+}
+
+export function captureStackFrames(): readonly RuntimeStackFrame[] {
+  const prepareStackTraceDescriptor = Object.getOwnPropertyDescriptor(Error, 'prepareStackTrace');
+  Object.defineProperty(Error, 'prepareStackTrace', {
+    configurable: true,
+    value: (_error: unknown, callSites: readonly unknown[]) => callSites,
+    writable: true,
+  });
+
+  const frames: RuntimeStackFrame[] = [];
+  try {
+    const callSites: unknown = new Error().stack;
+    if (!Array.isArray(callSites)) {
+      throw new Error('Cannot capture structured micro-frontend stack frames');
+    }
+    for (const callSite of callSites) {
+      if (typeof callSite !== 'object' || callSite == null) {
+        continue;
+      }
+      if (!('getFileName' in callSite)) {
+        continue;
+      }
+      const getFileName: unknown = 'getFileName' in callSite ? callSite.getFileName : undefined;
+      const sourceURL: unknown = typeof getFileName === 'function' ? getFileName.call(callSite) : null;
+      frames.push({ sourceURL: typeof sourceURL === 'string' ? sourceURL : null });
+    }
+  } finally {
+    if (prepareStackTraceDescriptor == null) {
+      Reflect.deleteProperty(Error, 'prepareStackTrace');
+    } else {
+      Object.defineProperty(Error, 'prepareStackTrace', prepareStackTraceDescriptor);
+    }
+  }
+
+  return frames;
+}
+
+export function resolveCurrentSourceURL(frames: readonly RuntimeStackFrame[]): string {
+  for (const frame of frames) {
+    if (frame.sourceURL != null && frame.sourceURL.length > 0) {
+      return frame.sourceURL;
+    }
+  }
+  throw new Error('Cannot determine the caller micro-frontend sourceURL');
+}


### PR DESCRIPTION
## Summary

- add `AppContainer.runtime.sourceURL` as the evaluated bundle identity
- export `getAppName()` for the current bundle
- export `findAppNameBySourceURL(sourceURL)` for runtimes that already provide a structured source URL
- make both APIs share the same exact container-registry resolver
- avoid stack-string parsing, fixed frame indices, and mutable last-evaluated global state

## Runtime contract

The micro-frontend package code is emitted into each application bundle. `getAppName()` reads `new Error().stack` through a temporary structured stack formatter, obtains the current bundle source URL, and exact-matches it against registered containers.

`findAppNameBySourceURL(sourceURL)` performs the same exact registry lookup without capturing a stack. It returns `null` for unknown URLs and for ambiguous URLs registered by different apps.

## Verification

- 32 test files, 163 tests passed
- typecheck passed
- ESLint passed
- package build passed
- Integrations workflow passed
- pkg.pr.new workflow passed

Preview: `https://pkg.pr.new/@granite-js/micro-frontend@367.tgz?commit=02e7468`