### PR TITLE
fix(micro-frontend): evaluate Android asset bundles

### DIFF
--- a/.changeset/bright-assets-evaluate.md
+++ b/.changeset/bright-assets-evaluate.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/micro-frontend': patch
+---
+
+Support evaluating Android bundles packaged under `assets://` locators.

--- a/packages/micro-frontend/README.md
+++ b/packages/micro-frontend/README.md
@@ -159,7 +159,8 @@ app name exactly rather than routing it to another remote.
 ## JavaScript runtime
 
 The adapter owns bundle selection, download, integrity verification, and
-caching. It returns an absolute local bundle path.
+caching. It returns an absolute local bundle path, or an Android `assets://`
+locator for a bundle packaged in the application.
 
 ```ts
 import { createMicroFrontendRuntime } from '@granite-js/micro-frontend';
@@ -211,7 +212,7 @@ The public runtime API is:
 | -------------------------- | --------------------------------------------------------------- |
 | `preloadApp(appName)`      | Load and evaluate one app without importing an exposed module.  |
 | `importApp(request)`       | Ensure the app is evaluated and import `appName/exposedModule`. |
-| `evaluateScript(filePath)` | Evaluate an already-local bundle in the retained runtime.       |
+| `evaluateScript(filePath)` | Evaluate a local file or Android packaged asset in the retained runtime. |
 | `onEvent(listener)`        | Subscribe to native open, close, and visibility events.         |
 
 The host can provide `onLifecycleEvent` when creating the runtime for logging
@@ -362,7 +363,8 @@ The brownfield application must:
    boundary;
 4. bind native screen lifecycle to the session APIs below;
 5. install a Portal destination with the same `sessionId`;
-6. provide `adapter.loadBundle()` and return an absolute verified bundle path;
+6. provide `adapter.loadBundle()` and return an absolute verified bundle path,
+   or an Android `assets://` locator for a verified packaged bundle;
 7. keep the React tree mounted until native teardown emits `closeApp`; and
 8. keep Granite's base brownfield view APIs, such as scheme resolution and
    closing the current Granite view, in the Granite host integration. They are

--- a/packages/micro-frontend/android/src/main/cpp/BundleEvaluator.cpp
+++ b/packages/micro-frontend/android/src/main/cpp/BundleEvaluator.cpp
@@ -5,6 +5,7 @@
 
 namespace granite::microfrontend {
 
+using facebook::jni::JArrayByte;
 using facebook::jni::JString;
 using facebook::jni::alias_ref;
 using facebook::jsi::Runtime;
@@ -12,7 +13,29 @@ using facebook::jsi::StringBuffer;
 
 void BundleEvaluator::registerNatives() {
   registerHybrid(
-      {makeNativeMethod("evaluateFileSync", BundleEvaluator::evaluateFileSync)});
+      {makeNativeMethod("evaluateFileSync", BundleEvaluator::evaluateFileSync),
+       makeNativeMethod("evaluateScriptSync", BundleEvaluator::evaluateScriptSync)});
+}
+
+void BundleEvaluator::evaluateScriptSync(
+    alias_ref<jhybridobject>,
+    jlong runtimePointer,
+    alias_ref<JArrayByte> scriptData,
+    alias_ref<JString> sourceUrl) {
+  if (runtimePointer == 0) {
+    facebook::jni::throwNewJavaException(
+        "java/lang/IllegalStateException", "JavaScript runtime is unavailable");
+    return;
+  }
+
+  auto pinnedScriptData = scriptData->pin();
+  std::string source{
+      reinterpret_cast<const char *>(pinnedScriptData.get()),
+      pinnedScriptData.size()};
+  auto *runtime = reinterpret_cast<Runtime *>(runtimePointer);
+  runtime->evaluateJavaScript(
+      std::make_shared<StringBuffer>(std::move(source)),
+      sourceUrl->toStdString());
 }
 
 void BundleEvaluator::evaluateFileSync(

--- a/packages/micro-frontend/android/src/main/cpp/BundleEvaluator.h
+++ b/packages/micro-frontend/android/src/main/cpp/BundleEvaluator.h
@@ -15,6 +15,12 @@ struct BundleEvaluator : facebook::jni::HybridClass<BundleEvaluator> {
       jlong runtimePointer,
       facebook::jni::alias_ref<facebook::jni::JString> filePath,
       facebook::jni::alias_ref<facebook::jni::JString> sourceUrl);
+
+  static void evaluateScriptSync(
+      facebook::jni::alias_ref<jhybridobject>,
+      jlong runtimePointer,
+      facebook::jni::alias_ref<facebook::jni::JArrayByte> scriptData,
+      facebook::jni::alias_ref<facebook::jni::JString> sourceUrl);
 };
 
 } // namespace granite::microfrontend

--- a/packages/micro-frontend/android/src/main/java/run/granite/microfrontend/BundleEvaluator.kt
+++ b/packages/micro-frontend/android/src/main/java/run/granite/microfrontend/BundleEvaluator.kt
@@ -1,10 +1,47 @@
 package run.granite.microfrontend
 
+import android.content.res.AssetManager
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.annotations.FrameworkAPI
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
+
+internal sealed interface ResolvedBundleSource {
+    val sourceUrl: String
+
+    data class Asset(
+        val scriptData: ByteArray,
+        override val sourceUrl: String,
+    ) : ResolvedBundleSource
+
+    data class FilePath(
+        val filePath: String,
+        override val sourceUrl: String,
+    ) : ResolvedBundleSource
+}
+
+internal fun resolveBundleSource(assetManager: AssetManager, bundlePath: String): ResolvedBundleSource {
+    if (bundlePath.startsWith(ASSET_PREFIX)) {
+        val assetPath = bundlePath.removePrefix(ASSET_PREFIX)
+        require(assetPath.isNotBlank()) { "Bundle asset path must not be blank: $bundlePath" }
+        val scriptData = assetManager.open(assetPath).use { it.readBytes() }
+        if (scriptData.isEmpty()) {
+            throw IOException("Bundle asset is empty: $bundlePath")
+        }
+        return ResolvedBundleSource.Asset(scriptData, bundlePath)
+    }
+
+    val file = File(bundlePath)
+    require(file.isAbsolute) { "Bundle path must be absolute: $bundlePath" }
+    if (!file.exists()) {
+        throw FileNotFoundException("Bundle file does not exist: $bundlePath")
+    }
+    if (!file.canRead()) {
+        throw IOException("Bundle file is not readable: $bundlePath")
+    }
+    return ResolvedBundleSource.FilePath(bundlePath, file.toURI().toString())
+}
 
 @OptIn(FrameworkAPI::class)
 internal class BundleEvaluator(
@@ -22,20 +59,21 @@ internal class BundleEvaluator(
         sourceUrl: String,
     )
 
+    private external fun evaluateScriptSync(
+        runtimePointer: Long,
+        scriptData: ByteArray,
+        sourceUrl: String,
+    )
+
     @Throws(FileNotFoundException::class, IOException::class)
     fun evaluateFile(filePath: String) {
-        val file = File(filePath)
-        require(file.isAbsolute) { "Bundle path must be absolute: $filePath" }
-        if (!file.exists()) {
-            throw FileNotFoundException("Bundle file does not exist: $filePath")
-        }
-        if (!file.canRead()) {
-            throw IOException("Bundle file is not readable: $filePath")
-        }
-
+        val source = resolveBundleSource(reactContext.assets, filePath)
         val runtimePointer = reactContext.javaScriptContextHolder?.get()
             ?: throw IllegalStateException("JavaScript runtime is unavailable")
-        evaluateFileSync(runtimePointer, filePath, file.toURI().toString())
+        when (source) {
+            is ResolvedBundleSource.Asset -> evaluateScriptSync(runtimePointer, source.scriptData, source.sourceUrl)
+            is ResolvedBundleSource.FilePath -> evaluateFileSync(runtimePointer, source.filePath, source.sourceUrl)
+        }
     }
 
     private companion object {
@@ -44,3 +82,5 @@ internal class BundleEvaluator(
         }
     }
 }
+
+private const val ASSET_PREFIX = "assets://"

--- a/packages/micro-frontend/android/src/test/java/run/granite/microfrontend/BundleEvaluatorTest.kt
+++ b/packages/micro-frontend/android/src/test/java/run/granite/microfrontend/BundleEvaluatorTest.kt
@@ -1,0 +1,42 @@
+package run.granite.microfrontend
+
+import android.content.res.AssetManager
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import java.io.ByteArrayInputStream
+import java.io.File
+
+class BundleEvaluatorTest {
+    @Test
+    fun `asset bundle locator reads the built-in bundle through AssetManager`() {
+        val assetManager = mock(AssetManager::class.java)
+        val scriptData = "built-in bundle".toByteArray()
+        `when`(assetManager.open("bundles/example.hbc")).thenReturn(ByteArrayInputStream(scriptData))
+
+        val source = resolveBundleSource(assetManager, "assets://bundles/example.hbc")
+
+        assertTrue(source is ResolvedBundleSource.Asset)
+        assertArrayEquals(scriptData, (source as ResolvedBundleSource.Asset).scriptData)
+        assertEquals("assets://bundles/example.hbc", source.sourceUrl)
+        verify(assetManager).open("bundles/example.hbc")
+    }
+
+    @Test
+    fun `absolute file path keeps filesystem bundle evaluation`() {
+        val bundleFile = File.createTempFile("granite-micro-frontend", ".hbc")
+        try {
+            val source = resolveBundleSource(mock(AssetManager::class.java), bundleFile.absolutePath)
+
+            assertTrue(source is ResolvedBundleSource.FilePath)
+            assertEquals(bundleFile.absolutePath, (source as ResolvedBundleSource.FilePath).filePath)
+            assertEquals(bundleFile.toURI().toString(), source.sourceUrl)
+        } finally {
+            bundleFile.delete()
+        }
+    }
+}

--- a/packages/micro-frontend/src/types.ts
+++ b/packages/micro-frontend/src/types.ts
@@ -5,6 +5,7 @@ export interface MicroFrontendBundleRequest {
 }
 
 export interface MicroFrontendBundle {
+  /** An absolute local file path, or an Android `assets://` locator for a packaged bundle. */
   readonly filePath: string;
 }
 


### PR DESCRIPTION
## Summary

- resolve Android `assets://` bundle locators through `AssetManager`
- evaluate packaged bundle bytes on the retained Hermes runtime through the package JNI evaluator
- preserve the existing absolute filesystem path flow and document both supported locator forms

## Verification

- `yarn workspace @granite-js/micro-frontend test` (154 tests)
- `yarn workspace @granite-js/micro-frontend typecheck`
- `yarn workspace @granite-js/micro-frontend build`
- Android Kotlin resolver regression test with red to green proof
- Android NDK/AAR build for arm64-v8a, armeabi-v7a, x86, and x86_64