### PR TITLE
fix(micro-frontend): register pending routes before initial URL

### DIFF
--- a/.changeset/calm-routes-preload.md
+++ b/.changeset/calm-routes-preload.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/micro-frontend': patch
+---
+
+Register pending host components with the configured app scheme so route evaluation works before an initial URL is available and does not inherit another app's scheme.

--- a/packages/micro-frontend/src/createRoute.spec.ts
+++ b/packages/micro-frontend/src/createRoute.spec.ts
@@ -39,20 +39,27 @@ describe('createRoute', () => {
     Reflect.deleteProperty(globalThis, '__granite');
   });
 
-  it('registers the host pending component once for the native scheme without a cross-app fallback', () => {
-    reactNative.getSchemeUri.mockReturnValue('granite://host/app-1/product/123?tab=review');
+  it.each(['', 'other://host/app-2/product/456', 'granite://host/app-1/product/123?tab=review'])(
+    'registers the host pending component from app configuration when the current URL is %j',
+    (currentURL) => {
+      // Given
+      reactNative.getSchemeUri.mockReturnValue(currentURL);
 
-    createRoute('/product/:productId', {
-      component: ProductPendingComponent,
-      hostPendingComponent: ProductPendingComponent,
-    });
+      // When
+      createRoute('/product/:productId', {
+        component: ProductPendingComponent,
+        hostPendingComponent: ProductPendingComponent,
+      });
 
-    expect(reactNative.getSchemeUri).toHaveBeenCalledOnce();
-    expect(resolvePendingHostComponent('granite://host/app-1/product/123?tab=review')?.component).toBe(
-      ProductPendingComponent
-    );
-    expect(resolvePendingHostComponent({ appName: 'app-2', routePath: '/product/123' })).toBeNull();
-  });
+      // Then
+      expect(reactNative.getSchemeUri).not.toHaveBeenCalled();
+      expect(resolvePendingHostComponent('granite://host/app-1/product/123?tab=review')?.component).toBe(
+        ProductPendingComponent
+      );
+      expect(resolvePendingHostComponent({ appName: 'app-2', routePath: '/product/123' })).toBeNull();
+      expect(resolvePendingHostComponent('other://host/app-1/product/123')).toBeNull();
+    }
+  );
 
   it('still creates the route when the host app configuration is unavailable', () => {
     // Given

--- a/packages/micro-frontend/src/createRoute.ts
+++ b/packages/micro-frontend/src/createRoute.ts
@@ -1,6 +1,5 @@
 import {
   createRoute as createGraniteRoute,
-  getSchemeUri,
   type RegisterScreenInput,
   type RouteOptions,
   useNavigation,
@@ -66,11 +65,10 @@ function getCurrentGraniteApp(): PendingHostComponentAppConfig | null {
 
   const host = granite['app']['host'];
   const name = granite['app']['name'];
-  if (typeof host !== 'string' || typeof name !== 'string') {
+  const scheme = granite['app']['scheme'];
+  if (typeof host !== 'string' || typeof name !== 'string' || typeof scheme !== 'string') {
     return null;
   }
-
-  const scheme = new URL(getSchemeUri()).protocol.replace(/:$/g, '');
 
   return {
     name,


### PR DESCRIPTION
A remote bundle can register routes while the native initial URL is still empty during preload. Reading that URL in `createRoute()` throws before evaluation completes; a subsequent attempt can then fail because the app container was already registered.

Use the app's configured scheme when registering pending host components. This also prevents a different active app's URL from determining the route scheme.

Validation: 165 micro-frontend tests pass, including empty, unrelated, and matching current URLs; package typecheck, focused lint, and build pass. All 9 CI checks pass. The published `@granite-js/micro-frontend@9641de8` preview was installed in a consumer and verified on iOS: preload followed by navigation from a web view to a native screen, then back and re-entry, renders successfully without either error.