### PR TITLE
feat(micro-frontend): expose session navigation subscriptions

### DIFF
--- a/.changeset/session-navigation-handles.md
+++ b/.changeset/session-navigation-handles.md
@@ -1,0 +1,8 @@
+---
+'@granite-js/micro-frontend': minor
+'@granite-js/react-native': minor
+---
+
+Add `runtime.sessions` for observing existing and future sessions outside React. Each session owns a separate React Navigation ref and exposes lifecycle subscriptions with per-session cleanup. Deprecate `onLifecycleEvent` while preserving its payloads and teardown timing through the new subscription path.
+
+Registered apps accept a per-instance `navigationContainerRef` prop so hosts can connect the session handle without sharing registration-time refs between mounted app instances.

--- a/.changeset/session-navigation-handles.md
+++ b/.changeset/session-navigation-handles.md
@@ -1,6 +1,6 @@
 ---
-'@granite-js/micro-frontend': minor
-'@granite-js/react-native': minor
+'@granite-js/micro-frontend': patch
+'@granite-js/react-native': patch
 ---
 
 Add `runtime.sessions` for observing existing and future sessions outside React. Each session owns a separate React Navigation ref and exposes lifecycle subscriptions with per-session cleanup. Deprecate `onLifecycleEvent` while preserving its payloads and teardown timing through the new subscription path.

--- a/packages/micro-frontend/README.md
+++ b/packages/micro-frontend/README.md
@@ -182,9 +182,6 @@ const runtime = createMicroFrontendRuntime({
       return { filePath };
     },
   },
-  onLifecycleEvent(event) {
-    reportMicroFrontendLifecycle(event);
-  },
 });
 
 await runtime.preloadApp('cart');
@@ -217,35 +214,74 @@ route best-effort native preload failures to its observability provider.
 
 The public runtime API is:
 
-| API                        | Responsibility                                                  |
-| -------------------------- | --------------------------------------------------------------- |
-| `preloadApp(appName)`      | Load and evaluate one app without importing an exposed module.  |
-| `importApp(request)`       | Ensure the app is evaluated and import `appName/exposedModule`. |
+| API                        | Responsibility                                                           |
+| -------------------------- | ------------------------------------------------------------------------ |
+| `preloadApp(appName)`      | Load and evaluate one app without importing an exposed module.           |
+| `importApp(request)`       | Ensure the app is evaluated and import `appName/exposedModule`.          |
 | `evaluateScript(filePath)` | Evaluate a local file or Android packaged asset in the retained runtime. |
-| `onEvent(listener)`        | Subscribe to native open, close, and visibility events.         |
+| `onEvent(listener)`        | Subscribe to native open, close, and visibility events.                  |
+| `sessions`                 | Discover session handles and observe their navigation and lifecycle.     |
 
-The host can provide `onLifecycleEvent` when creating the runtime for logging
-and other observability integrations. Each event contains `session.id`,
-`session.appName`, and the `activeSessions` snapshot when the callback is
-emitted. The callback has the same lifetime as the runtime.
+### Session subscriptions
+
+SDKs can subscribe outside React. Each handle belongs to one native session,
+including when multiple sessions load the same app bundle:
 
 ```ts
-const runtime = createMicroFrontendRuntime({
-  adapter,
-  onLifecycleEvent(event) {
-    reportMicroFrontendLifecycle({
-      ...event,
-      activeSessionCount: event.activeSessions.length,
-    });
-  },
+const { sessions } = runtime;
+
+const unsubscribe = sessions.subscribe((session) => {
+  const removeState = session.navigation.addListener('state', (event) => {
+    reportNavigationState(session.id, event);
+  });
+  const removeLifecycle = session.addListener('lifecycle', (event) => {
+    reportSessionLifecycle(event);
+  });
+
+  return () => {
+    removeState();
+    removeLifecycle();
+  };
 });
+
+const session = sessions.get(sessionId);
+const state = session?.navigation.getRootState();
+const activeSessions = sessions.getSnapshot();
 ```
+
+`subscribe` visits existing sessions immediately and future sessions once they
+are admitted by a native `openApp` event. This is discovery, not a replay of
+`mounted` or navigation `ready` events. A handle is available before its React
+tree or navigator is ready; use `navigation.isReady()` and the native navigation
+`ready` event when needed. A late subscriber can read the current state directly.
+
+Each `navigation` is a distinct React Navigation container ref with the original
+`addListener(event, listener)` event types, payloads, and unsubscribe functions.
+It never switches to another session. Connect it to the app instance as shown in
+the host example below. This explicit prop also works across separately
+evaluated host and remote bundles without relying on shared React Context.
+
+`get` and `getSnapshot` exclude sessions once native requests their removal.
+Existing subscribers remain attached until lifecycle teardown finishes. The
+per-session cleanup returned by a subscriber runs once after `unmounted`, or
+when that observer unsubscribes. Unsubscribing does not close a session or emit
+an `unmounted` event. A session opened and closed before React commits only runs
+its subscription cleanup, since it never reached `mounted`.
+
+Lifecycle events keep `phase`, `session.id`, `session.appName`, and the
+`activeSessions` snapshot from the emission time. Consumer callback failures
+are reported without interrupting other observers or teardown.
 
 `mounted` is emitted after the session is committed to React state. `unmounted`
 is emitted after the session is removed. When the session was the app's last
 active session, Granite waits for the app's registered dispose callbacks before
 emitting `unmounted`. Callback failures are reported without interrupting the
 session lifecycle.
+
+The runtime option `onLifecycleEvent` is deprecated. Existing callbacks continue
+to receive the same lifecycle events through the session subscription path.
+Migrate with `sessions.subscribe(session => session.addListener('lifecycle', callback))`
+and keep the returned unsubscribe function for your SDK's lifetime.
 
 Remote code can register an idempotent callback for explicit app-level resource
 cleanup:
@@ -276,7 +312,7 @@ destination with `MicroFrontendSessionProvider` so native presentation state
 joins Granite's existing visibility context.
 
 ```tsx
-const sessions = useMicroFrontendSessions(runtime);
+const sessionStates = useMicroFrontendSessions(runtime);
 
 function SessionRoot({ session }: { readonly session: MicroFrontendSessionState }) {
   const App = useMemo(() => lazy(() => runtime.importApp(`${session.appName}/App`)), [session.appName]);
@@ -284,7 +320,7 @@ function SessionRoot({ session }: { readonly session: MicroFrontendSessionState 
   return (
     <Portal hostName={session.sessionId}>
       <MicroFrontendSessionProvider sessionId={session.sessionId} presentationVisibility={session.isVisible}>
-        <App scheme={session.scheme} />
+        <App scheme={session.scheme} navigationContainerRef={runtime.sessions.get(session.sessionId)?.navigation} />
       </MicroFrontendSessionProvider>
     </Portal>
   );
@@ -299,6 +335,15 @@ The provider exposes the native session identity and combines
 `presentationVisibility` with Granite's existing `VisibilityChangedProvider`.
 Remote apps continue to read the final app, navigation, and native-session
 visibility through `useVisibility()`.
+
+Apps returned by `Granite.registerApp` accept the instance-level
+`navigationContainerRef` prop. It overrides both `router.navigationContainerRef`
+and `router.ref` captured at registration, while leaving other router options
+unchanged. Custom app roots must forward the prop to their own
+`NavigationContainer`. New hosts and remotes need this connection before relying
+on session navigation observation; older remote roots that ignore the prop do
+not expose their navigation through this API. Replace module-level navigation
+getters with an explicit session handle instead of selecting by app name.
 
 Remote apps use Granite's `useVisibility()` for visibility and
 `closeView()` to close the current brownfield view. They do not receive

--- a/packages/micro-frontend/package.json
+++ b/packages/micro-frontend/package.json
@@ -60,6 +60,7 @@
     "@standard-schema/spec": "^1.0.0"
   },
   "peerDependencies": {
+    "@granite-js/native": "*",
     "@granite-js/plugin-core": "*",
     "@granite-js/react-native": "*",
     "react": "*",
@@ -72,6 +73,7 @@
   },
   "devDependencies": {
     "@babel/types": "7.28.5",
+    "@granite-js/native": "workspace:*",
     "@granite-js/plugin-core": "workspace:*",
     "@granite-js/react-native": "workspace:*",
     "@types/babel__core": "^7.20.5",

--- a/packages/micro-frontend/src/createMicroFrontendRuntime.spec.ts
+++ b/packages/micro-frontend/src/createMicroFrontendRuntime.spec.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createMicroFrontendRuntime } from './createMicroFrontendRuntime';
+import type { NativeMicroFrontendRuntimeEvent } from './runtime/createMicroFrontendRuntime';
 import { emitMicroFrontendLifecycleEvent } from './runtime/lifecycle';
 import type { MicroFrontendLifecycleEvent } from './types';
+
+vi.mock('./specs/NativeGraniteMicroFrontendRuntime', () => ({
+  default: {
+    onEvent(listener: (event: NativeMicroFrontendRuntimeEvent) => void) {
+      listener({ name: 'openApp', params: { sessionId: 'app-1:1', appName: 'app-1', scheme: 'granite://app-1/home' } });
+      return { remove: () => undefined };
+    },
+    startEventDelivery: () => undefined,
+  },
+}));
 
 describe('createMicroFrontendRuntime', () => {
   it('connects the host lifecycle callback to the created runtime', () => {
@@ -23,9 +34,11 @@ describe('createMicroFrontendRuntime', () => {
     };
 
     // When
+    const subscription = runtime.onEvent(() => undefined);
     emitMicroFrontendLifecycleEvent(runtime, event);
 
     // Then
     expect(onLifecycleEvent).toHaveBeenCalledWith(event);
+    subscription.remove();
   });
 });

--- a/packages/micro-frontend/src/createMicroFrontendRuntime.ts
+++ b/packages/micro-frontend/src/createMicroFrontendRuntime.ts
@@ -7,6 +7,7 @@ import type { MicroFrontendAdapter, MicroFrontendLifecycleCallback, MicroFronten
 
 export interface CreateMicroFrontendRuntimeOptions {
   readonly adapter: MicroFrontendAdapter;
+  /** @deprecated Subscribe through runtime.sessions and session.addListener('lifecycle', listener). */
   readonly onLifecycleEvent?: MicroFrontendLifecycleCallback;
   readonly onPreloadError?: (error: unknown) => void;
 }

--- a/packages/micro-frontend/src/index.ts
+++ b/packages/micro-frontend/src/index.ts
@@ -18,10 +18,7 @@ export type {
   RegisterPendingHostComponentRouteOptions,
   ResolvedPendingHostComponent,
 } from './host/types';
-export {
-  createPendingHostComponentRoutePrefix,
-  normalizeRoutePath,
-} from './host/routeMatcher';
+export { createPendingHostComponentRoutePrefix, normalizeRoutePath } from './host/routeMatcher';
 export {
   hidePendingHostComponent,
   installPendingHostComponentBridge,
@@ -37,6 +34,11 @@ export {
 export type { MicroFrontendSession, MicroFrontendSessionProviderProps } from './session/MicroFrontendSessionContext';
 export { useMicroFrontendSessions } from './session/useMicroFrontendSessions';
 export type { MicroFrontendSessionState } from './session/useMicroFrontendSessions';
+export type {
+  MicroFrontendSessionHandle,
+  MicroFrontendSessions,
+  MicroFrontendSessionSubscriber,
+} from './session/sessionTypes';
 export type {
   AppContainer,
   AppContainerRuntime,

--- a/packages/micro-frontend/src/runtime/createMicroFrontendRuntime.ts
+++ b/packages/micro-frontend/src/runtime/createMicroFrontendRuntime.ts
@@ -8,9 +8,10 @@ import type {
 } from '../types';
 import { AppContainerNotFoundError, InvalidAppNameError } from './errors';
 import { getMicroFrontendGlobalContext } from './globalContext';
-import { setMicroFrontendLifecycleCallback } from './lifecycle';
+import { setMicroFrontendSessionStore } from './lifecycle';
 import { installNativeComponentRegistryCompatibility } from './nativeComponentRegistryCompatibility';
 import { parseAppRequest } from './parseAppRequest';
+import { createSessionStore } from '../session/sessionStore';
 
 export interface NativeMicroFrontendRuntimeEvent {
   readonly name: string;
@@ -51,6 +52,7 @@ export function createMicroFrontendRuntimeWithDependencies(
 ): MicroFrontendRuntimeApi {
   // A fulfilled promise is the evaluated-state cache. Rejected evaluations remove themselves.
   const appEvaluations = new Map<string, Promise<void>>();
+  const sessionStore = createSessionStore();
 
   function resetFailedEvaluation(appName: string) {
     appEvaluations.delete(appName);
@@ -94,6 +96,7 @@ export function createMicroFrontendRuntimeWithDependencies(
   }
 
   const runtime: MicroFrontendRuntimeApi = {
+    sessions: sessionStore.sessions,
     evaluateScript,
     preloadApp,
     async importApp<TModule>(request: AppRequest): Promise<TModule> {
@@ -109,7 +112,13 @@ export function createMicroFrontendRuntimeWithDependencies(
             void preloadApp(parsedEvent.params.appName).catch(dependencies.onPreloadError);
             return;
           case 'openApp':
+            sessionStore.open({ id: parsedEvent.params.sessionId, appName: parsedEvent.params.appName });
+            listener(parsedEvent);
+            return;
           case 'closeApp':
+            sessionStore.close(parsedEvent.params.sessionId);
+            listener(parsedEvent);
+            return;
           case 'sessionVisibilityChanged':
             listener(parsedEvent);
             return;
@@ -124,7 +133,11 @@ export function createMicroFrontendRuntimeWithDependencies(
     },
   };
 
-  setMicroFrontendLifecycleCallback(runtime, dependencies.onLifecycleEvent);
+  setMicroFrontendSessionStore(runtime, sessionStore);
+  const onLifecycleEvent = dependencies.onLifecycleEvent;
+  if (onLifecycleEvent != null) {
+    runtime.sessions.subscribe((session) => session.addListener('lifecycle', onLifecycleEvent));
+  }
 
   return runtime;
 }

--- a/packages/micro-frontend/src/runtime/lifecycle.spec.ts
+++ b/packages/micro-frontend/src/runtime/lifecycle.spec.ts
@@ -1,13 +1,21 @@
 import { describe, expect, it, vi } from 'vitest';
+import { createSessionStore } from '../session/sessionStore';
 import type { MicroFrontendLifecycleEvent } from '../types';
-import { emitMicroFrontendLifecycleEvent, setMicroFrontendLifecycleCallback } from './lifecycle';
+import { emitMicroFrontendLifecycleEvent, setMicroFrontendSessionStore } from './lifecycle';
+
+function subscribe(runtime: object, callback: (event: MicroFrontendLifecycleEvent) => void) {
+  const store = createSessionStore();
+  setMicroFrontendSessionStore(runtime, store);
+  store.sessions.subscribe((session) => session.addListener('lifecycle', callback));
+  store.open({ id: 'app-1:1', appName: 'app-1' });
+}
 
 describe('micro-frontend lifecycle callbacks', () => {
   it('notifies the callback configured for the runtime', () => {
     // Given
     const runtime = {};
     const callback = vi.fn();
-    setMicroFrontendLifecycleCallback(runtime, callback);
+    subscribe(runtime, callback);
     const event = createLifecycleEvent();
 
     // When
@@ -23,8 +31,8 @@ describe('micro-frontend lifecycle callbacks', () => {
     const secondRuntime = {};
     const firstCallback = vi.fn();
     const secondCallback = vi.fn();
-    setMicroFrontendLifecycleCallback(firstRuntime, firstCallback);
-    setMicroFrontendLifecycleCallback(secondRuntime, secondCallback);
+    subscribe(firstRuntime, firstCallback);
+    subscribe(secondRuntime, secondCallback);
     const event = createLifecycleEvent();
 
     // When
@@ -40,7 +48,7 @@ describe('micro-frontend lifecycle callbacks', () => {
     const runtime = {};
     const error = new Error('logging failed');
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    setMicroFrontendLifecycleCallback(runtime, () => {
+    subscribe(runtime, () => {
       throw error;
     });
     const event = createLifecycleEvent();
@@ -49,7 +57,7 @@ describe('micro-frontend lifecycle callbacks', () => {
     emitMicroFrontendLifecycleEvent(runtime, event);
 
     // Then
-    expect(consoleError).toHaveBeenCalledWith('Failed to run a micro-frontend lifecycle callback', error);
+    expect(consoleError).toHaveBeenCalledWith('Failed to run a micro-frontend session callback', error);
     consoleError.mockRestore();
   });
 });

--- a/packages/micro-frontend/src/runtime/lifecycle.ts
+++ b/packages/micro-frontend/src/runtime/lifecycle.ts
@@ -1,28 +1,12 @@
+import type { SessionStore } from '../session/sessionStore';
 import type { MicroFrontendLifecycleEvent } from '../types';
 
-const lifecycleCallbackByRuntime = new WeakMap<object, (event: MicroFrontendLifecycleEvent) => void>();
+const sessionsByRuntime = new WeakMap<object, SessionStore>();
 
-export function setMicroFrontendLifecycleCallback(
-  runtime: object,
-  callback: ((event: MicroFrontendLifecycleEvent) => void) | undefined
-): void {
-  if (callback == null) {
-    lifecycleCallbackByRuntime.delete(runtime);
-    return;
-  }
-
-  lifecycleCallbackByRuntime.set(runtime, callback);
+export function setMicroFrontendSessionStore(runtime: object, store: SessionStore): void {
+  sessionsByRuntime.set(runtime, store);
 }
 
 export function emitMicroFrontendLifecycleEvent(runtime: object, event: MicroFrontendLifecycleEvent): void {
-  const callback = lifecycleCallbackByRuntime.get(runtime);
-  if (callback == null) {
-    return;
-  }
-
-  try {
-    callback(event);
-  } catch (error) {
-    console.error('Failed to run a micro-frontend lifecycle callback', error);
-  }
+  sessionsByRuntime.get(runtime)?.emit(event);
 }

--- a/packages/micro-frontend/src/session/sessionCallbacks.ts
+++ b/packages/micro-frontend/src/session/sessionCallbacks.ts
@@ -1,0 +1,9 @@
+export function runSessionCallback<T>(callback: () => T): T | undefined {
+  try {
+    return callback();
+  } catch (error) {
+    // no-excuse-ok: catch -- Consumer callbacks must not interrupt other subscribers or session teardown.
+    console.error('Failed to run a micro-frontend session callback', error);
+    return undefined;
+  }
+}

--- a/packages/micro-frontend/src/session/sessionNavigation.spec.tsx
+++ b/packages/micro-frontend/src/session/sessionNavigation.spec.tsx
@@ -1,0 +1,178 @@
+import {
+  BaseNavigationContainer,
+  createNavigatorFactory,
+  StackRouter,
+  useNavigationBuilder,
+} from '@granite-js/native/@react-navigation/native';
+import type { ReactNode } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+import { createMicroFrontendRuntime } from '../createMicroFrontendRuntime';
+import { useMicroFrontendSessions } from './useMicroFrontendSessions';
+import type { NativeMicroFrontendRuntimeEvent } from '../runtime/createMicroFrontendRuntime';
+
+Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', true);
+
+const listeners = vi.hoisted(() => new Set<(event: NativeMicroFrontendRuntimeEvent) => void>());
+vi.mock('../specs/NativeGraniteMicroFrontendRuntime', () => ({
+  default: {
+    evaluateScript: async () => undefined,
+    startEventDelivery: () => undefined,
+    onEvent: (listener: (event: NativeMicroFrontendRuntimeEvent) => void) => {
+      listeners.add(listener);
+      return { remove: () => listeners.delete(listener) };
+    },
+  },
+}));
+
+function TestNavigator({ children }: { readonly children: ReactNode }) {
+  const { state, descriptors, NavigationContent } = useNavigationBuilder(StackRouter, { children });
+  return <NavigationContent>{state.routes.map((route) => descriptors[route.key]?.render())}</NavigationContent>;
+}
+
+const Stack = createNavigatorFactory(TestNavigator)();
+const Screen = () => null;
+
+function createFixture() {
+  listeners.clear();
+  const onLifecycleEvent = vi.fn();
+  const runtime = createMicroFrontendRuntime({
+    adapter: { loadBundle: async () => ({ filePath: '/bundles/example.hbc' }) },
+    onPreloadError: () => undefined,
+    onLifecycleEvent,
+  });
+  function Host() {
+    return useMicroFrontendSessions(runtime).map((session) => (
+      <BaseNavigationContainer key={session.sessionId} ref={runtime.sessions.get(session.sessionId)?.navigation}>
+        <Stack.Navigator>
+          <Stack.Screen name="home" component={Screen} />
+          <Stack.Screen name="detail" component={Screen} />
+        </Stack.Navigator>
+      </BaseNavigationContainer>
+    ));
+  }
+  let renderer: ReactTestRenderer | undefined;
+  return {
+    runtime,
+    onLifecycleEvent,
+    mount: () =>
+      act(async () => {
+        renderer = create(<Host />);
+      }),
+    unmount: () => act(async () => renderer?.unmount()),
+    open: (id: string) => {
+      listeners.forEach((listener) =>
+        listener({ name: 'openApp', params: { sessionId: id, appName: 'example', scheme: 'granite://example/home' } })
+      );
+    },
+    close: (id: string) => {
+      listeners.forEach((listener) => listener({ name: 'closeApp', params: { sessionId: id } }));
+    },
+  };
+}
+
+describe('session navigation integration', () => {
+  it('keeps state, ready events and actions scoped to each mounted container', async () => {
+    // Given
+    const fixture = createFixture();
+    const stateEvents: string[] = [];
+    const readyEvents: string[] = [];
+    const stop = fixture.runtime.sessions.subscribe((session) => {
+      const state = session.navigation.addListener('state', () => stateEvents.push(session.id));
+      const ready = session.navigation.addListener('ready', () => readyEvents.push(session.id));
+      return () => {
+        state();
+        ready();
+      };
+    });
+    await fixture.mount();
+    await act(async () => {
+      fixture.open('one');
+      fixture.open('two');
+    });
+    const one = fixture.runtime.sessions.get('one');
+    const two = fixture.runtime.sessions.get('two');
+    expect(one?.navigation.isReady()).toBe(true);
+    expect(two?.navigation.isReady()).toBe(true);
+    expect(readyEvents).toEqual(['one', 'two']);
+    stateEvents.length = 0;
+
+    // When
+    await act(async () => one?.navigation.navigate('detail'));
+
+    // Then
+    expect(stateEvents).toEqual(['one']);
+    expect(one?.navigation.getCurrentRoute()?.name).toBe('detail');
+    expect(two?.navigation.getCurrentRoute()?.name).toBe('home');
+    stop();
+    await fixture.unmount();
+  });
+
+  it('keeps the remaining container operational when another session closes', async () => {
+    // Given
+    const fixture = createFixture();
+    const cleaned: string[] = [];
+    const stop = fixture.runtime.sessions.subscribe((session) => () => {
+      cleaned.push(session.id);
+    });
+    await fixture.mount();
+    await act(async () => {
+      fixture.open('one');
+      fixture.open('two');
+    });
+    const one = fixture.runtime.sessions.get('one');
+    const two = fixture.runtime.sessions.get('two');
+
+    // When
+    await act(async () => fixture.close('two'));
+    await act(async () => one?.navigation.navigate('detail'));
+
+    // Then
+    expect(cleaned).toEqual(['two']);
+    expect(two?.navigation.isReady()).toBe(false);
+    expect(one?.navigation.getCurrentRoute()?.name).toBe('detail');
+    expect(fixture.runtime.sessions.get('two')).toBeUndefined();
+    stop();
+    await fixture.unmount();
+  });
+
+  it('does not retain a session opened and closed before React commits', async () => {
+    // Given
+    const fixture = createFixture();
+    const cleanup = vi.fn();
+    const stop = fixture.runtime.sessions.subscribe(() => cleanup);
+    await fixture.mount();
+
+    // When
+    await act(async () => {
+      fixture.open('one');
+      fixture.close('one');
+    });
+
+    // Then
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(fixture.runtime.sessions.getSnapshot()).toEqual([]);
+    expect(fixture.onLifecycleEvent).not.toHaveBeenCalled();
+    stop();
+    await fixture.unmount();
+  });
+
+  it('preserves legacy lifecycle payloads while allowing independent subscribers', async () => {
+    // Given
+    const fixture = createFixture();
+    const onLifecycle = vi.fn();
+    const stop = fixture.runtime.sessions.subscribe((session) => session.addListener('lifecycle', onLifecycle));
+    await fixture.mount();
+
+    // When
+    await act(async () => fixture.open('one'));
+    await act(async () => fixture.close('one'));
+
+    // Then
+    expect(onLifecycle.mock.calls).toEqual(fixture.onLifecycleEvent.mock.calls);
+    expect(onLifecycle.mock.calls.map(([event]) => event.phase)).toEqual(['mounted', 'unmounted']);
+    expect(onLifecycle.mock.calls[1]?.[0].activeSessions).toEqual([]);
+    stop();
+    await fixture.unmount();
+  });
+});

--- a/packages/micro-frontend/src/session/sessionStore.spec.ts
+++ b/packages/micro-frontend/src/session/sessionStore.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSessionStore } from './sessionStore';
+
+describe('session subscriptions', () => {
+  it('keeps separate navigation handles for two instances of the same app', () => {
+    // Given
+    const store = createSessionStore();
+    const received: string[] = [];
+    store.sessions.subscribe((session) => {
+      received.push(session.id);
+    });
+
+    // When
+    store.open({ id: 'one', appName: 'example' });
+    store.open({ id: 'two', appName: 'example' });
+
+    // Then
+    expect(received).toEqual(['one', 'two']);
+    expect(store.sessions.get('one')?.navigation).not.toBe(store.sessions.get('two')?.navigation);
+  });
+
+  it('discovers existing sessions without replaying lifecycle transitions', () => {
+    // Given
+    const store = createSessionStore();
+    store.open({ id: 'one', appName: 'example' });
+    store.emit({ phase: 'mounted', session: { id: 'one', appName: 'example' }, activeSessions: [] });
+    const lifecycle = vi.fn();
+    const received: string[] = [];
+
+    // When
+    store.sessions.subscribe((session) => {
+      received.push(session.id);
+      return session.addListener('lifecycle', lifecycle);
+    });
+
+    // Then
+    expect(received).toEqual(['one']);
+    expect(lifecycle).not.toHaveBeenCalled();
+  });
+
+  it('cleans up only the closed session after its lifecycle event', () => {
+    // Given
+    const store = createSessionStore();
+    const events: string[] = [];
+    store.sessions.subscribe((session) => {
+      const remove = session.addListener('lifecycle', (event) => events.push(`${session.id}:${event.phase}`));
+      return () => {
+        events.push(`${session.id}:cleanup`);
+        remove();
+      };
+    });
+    store.open({ id: 'one', appName: 'example' });
+    store.open({ id: 'two', appName: 'example' });
+
+    // When
+    store.emit({
+      phase: 'unmounted',
+      session: { id: 'two', appName: 'example' },
+      activeSessions: [{ id: 'one', appName: 'example' }],
+    });
+
+    // Then
+    expect(events).toEqual(['two:unmounted', 'two:cleanup']);
+    expect(store.sessions.getSnapshot().map((session) => session.id)).toEqual(['one']);
+  });
+
+  it('stops one observer without closing sessions or notifying other observers', () => {
+    // Given
+    const store = createSessionStore();
+    const cleanup = vi.fn();
+    const lifecycle = vi.fn();
+    const stop = store.sessions.subscribe(() => cleanup);
+    store.sessions.subscribe((session) => session.addListener('lifecycle', lifecycle));
+    store.open({ id: 'one', appName: 'example' });
+
+    // When
+    stop();
+    stop();
+
+    // Then
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(lifecycle).not.toHaveBeenCalled();
+    expect(store.sessions.get('one')).toBeDefined();
+  });
+
+  it('keeps the original handle when an open event is repeated', () => {
+    // Given
+    const store = createSessionStore();
+    const subscriber = vi.fn();
+    store.sessions.subscribe(subscriber);
+    store.open({ id: 'one', appName: 'example' });
+    const original = store.sessions.get('one');
+
+    // When
+    store.open({ id: 'one', appName: 'example' });
+
+    // Then
+    expect(subscriber).toHaveBeenCalledOnce();
+    expect(store.sessions.get('one')).toBe(original);
+  });
+
+  it('runs setup cleanup when a session closes inside its subscriber', () => {
+    // Given
+    const store = createSessionStore();
+    const cleanup = vi.fn();
+    store.sessions.subscribe((session) => {
+      store.close(session.id);
+      return cleanup;
+    });
+
+    // When
+    store.open({ id: 'one', appName: 'example' });
+
+    // Then
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(store.sessions.getSnapshot()).toEqual([]);
+  });
+
+  it('continues delivering and cleaning up when a subscriber throws', () => {
+    // Given
+    const store = createSessionStore();
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const setupFailure = new Error('setup failure');
+    const cleanupFailure = new Error('cleanup failure');
+    const cleanup = vi.fn();
+    store.sessions.subscribe(() => {
+      throw setupFailure;
+    });
+    store.sessions.subscribe(() => () => {
+      throw cleanupFailure;
+    });
+    store.sessions.subscribe(() => cleanup);
+
+    // When
+    store.open({ id: 'one', appName: 'example' });
+    store.close('one');
+
+    // Then
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(store.sessions.getSnapshot()).toEqual([]);
+    log.mockRestore();
+  });
+
+  it('keeps the old handle detached when a later session is opened', () => {
+    // Given
+    const store = createSessionStore();
+    store.open({ id: 'one', appName: 'example' });
+    const original = store.sessions.get('one');
+    store.close('one');
+
+    // When
+    store.open({ id: 'two', appName: 'example' });
+
+    // Then
+    expect(original?.navigation.current).toBeNull();
+    expect(original?.navigation).not.toBe(store.sessions.get('two')?.navigation);
+  });
+});

--- a/packages/micro-frontend/src/session/sessionStore.ts
+++ b/packages/micro-frontend/src/session/sessionStore.ts
@@ -1,0 +1,149 @@
+import { createNavigationContainerRef, type ParamListBase } from '@granite-js/native/@react-navigation/native';
+import type {
+  MicroFrontendLifecycleCallback,
+  MicroFrontendLifecycleEvent,
+  MicroFrontendLifecycleSession,
+} from '../types';
+import { runSessionCallback } from './sessionCallbacks';
+import type { MicroFrontendSessionHandle, MicroFrontendSessions, MicroFrontendSessionSubscriber } from './sessionTypes';
+
+interface SessionEntry {
+  readonly handle: MicroFrontendSessionHandle;
+  readonly listeners: Set<MicroFrontendLifecycleCallback>;
+  status: 'opening' | 'mounted' | 'closing' | 'closed';
+}
+
+interface Observer {
+  readonly subscriber: MicroFrontendSessionSubscriber;
+  readonly cleanups: Map<SessionEntry, (() => void) | undefined>;
+  active: boolean;
+}
+
+export interface SessionStore {
+  readonly sessions: MicroFrontendSessions;
+  readonly open: (session: MicroFrontendLifecycleSession) => void;
+  readonly close: (sessionId: string) => void;
+  readonly emit: (event: MicroFrontendLifecycleEvent) => void;
+}
+
+export function createSessionStore(): SessionStore {
+  const entries = new Map<string, SessionEntry>();
+  const observers = new Set<Observer>();
+
+  function cleanup(observer: Observer, entry: SessionEntry) {
+    const callback = observer.cleanups.get(entry);
+    observer.cleanups.delete(entry);
+    if (callback != null) {
+      runSessionCallback(callback);
+    }
+  }
+
+  function attach(observer: Observer, entry: SessionEntry) {
+    if (!observer.active || entry.status === 'closed' || observer.cleanups.has(entry)) {
+      return;
+    }
+    observer.cleanups.set(entry, undefined);
+    const callback = runSessionCallback(() => observer.subscriber(entry.handle));
+    if (callback == null) {
+      return;
+    }
+    if (observer.active && observer.cleanups.has(entry)) {
+      observer.cleanups.set(entry, callback);
+    } else {
+      runSessionCallback(callback);
+    }
+  }
+
+  function dispose(entry: SessionEntry) {
+    entry.status = 'closed';
+    if (entries.get(entry.handle.id) === entry) {
+      entries.delete(entry.handle.id);
+    }
+    for (const observer of [...observers]) {
+      cleanup(observer, entry);
+    }
+    entry.listeners.clear();
+    entry.handle.navigation.current = null;
+  }
+
+  const sessions: MicroFrontendSessions = {
+    get: (id) => {
+      const entry = entries.get(id);
+      return entry?.status === 'closing' ? undefined : entry?.handle;
+    },
+    getSnapshot: () => [...entries.values()].filter((entry) => entry.status !== 'closing').map((entry) => entry.handle),
+    subscribe: (subscriber) => {
+      const observer: Observer = { subscriber, cleanups: new Map(), active: true };
+      observers.add(observer);
+      for (const entry of [...entries.values()]) {
+        if (entry.status !== 'closing') {
+          attach(observer, entry);
+        }
+      }
+      return () => {
+        observer.active = false;
+        observers.delete(observer);
+        for (const entry of [...observer.cleanups.keys()]) {
+          cleanup(observer, entry);
+        }
+      };
+    },
+  };
+
+  return {
+    sessions,
+    open: (session) => {
+      if (entries.has(session.id)) {
+        return;
+      }
+      const listeners = new Set<MicroFrontendLifecycleCallback>();
+      const entry: SessionEntry = {
+        status: 'opening',
+        listeners,
+        handle: {
+          id: session.id,
+          appName: session.appName,
+          navigation: createNavigationContainerRef<ParamListBase>(),
+          addListener: (_event, listener) => {
+            if (entry.status !== 'closed') {
+              listeners.add(listener);
+            }
+            return () => listeners.delete(listener);
+          },
+        },
+      };
+      entries.set(session.id, entry);
+      for (const observer of [...observers]) {
+        attach(observer, entry);
+      }
+    },
+    close: (id) => {
+      const entry = entries.get(id);
+      if (entry == null) {
+        return;
+      }
+      if (entry.status === 'opening') {
+        dispose(entry);
+      } else {
+        entry.status = 'closing';
+      }
+    },
+    emit: (event) => {
+      const entry = entries.get(event.session.id);
+      if (entry == null) {
+        return;
+      }
+      if (event.phase === 'mounted') {
+        entry.status = 'mounted';
+      }
+      for (const listener of [...entry.listeners]) {
+        if (entry.listeners.has(listener)) {
+          runSessionCallback(() => listener(event));
+        }
+      }
+      if (event.phase === 'unmounted') {
+        dispose(entry);
+      }
+    },
+  };
+}

--- a/packages/micro-frontend/src/session/sessionTypes.ts
+++ b/packages/micro-frontend/src/session/sessionTypes.ts
@@ -1,0 +1,16 @@
+import type { NavigationContainerRefWithCurrent, ParamListBase } from '@granite-js/native/@react-navigation/native';
+import type { MicroFrontendLifecycleCallback, MicroFrontendLifecycleSession } from '../types';
+
+export interface MicroFrontendSessionHandle extends MicroFrontendLifecycleSession {
+  readonly navigation: NavigationContainerRefWithCurrent<ParamListBase>;
+  readonly addListener: (event: 'lifecycle', listener: MicroFrontendLifecycleCallback) => () => void;
+}
+
+export type MicroFrontendSessionSubscriber = (session: MicroFrontendSessionHandle) => void | (() => void);
+
+export interface MicroFrontendSessions {
+  readonly get: (sessionId: string) => MicroFrontendSessionHandle | undefined;
+  readonly getSnapshot: () => readonly MicroFrontendSessionHandle[];
+  /** Visits existing and future sessions. Returned per-session cleanups run on disposal or unsubscribe. */
+  readonly subscribe: (subscriber: MicroFrontendSessionSubscriber) => () => void;
+}

--- a/packages/micro-frontend/src/types.ts
+++ b/packages/micro-frontend/src/types.ts
@@ -1,3 +1,6 @@
+import type { GraniteAppRuntimeProps } from '@granite-js/react-native';
+import type { MicroFrontendSessions } from './session/sessionTypes';
+
 export type AppRequest = `${string}/${string}`;
 
 export interface MicroFrontendBundleRequest {
@@ -9,7 +12,7 @@ export interface MicroFrontendBundle {
   readonly filePath: string;
 }
 
-export interface MicroFrontendAppProps {
+export interface MicroFrontendAppProps extends GraniteAppRuntimeProps {
   readonly scheme: string;
 }
 
@@ -63,6 +66,7 @@ export interface MicroFrontendLifecycleEvent {
 export type MicroFrontendLifecycleCallback = (event: MicroFrontendLifecycleEvent) => void;
 
 export interface MicroFrontendRuntimeApi {
+  readonly sessions: MicroFrontendSessions;
   readonly evaluateScript: (filePath: string) => Promise<void>;
   readonly preloadApp: (appName: string) => Promise<void>;
   readonly importApp: <TModule>(request: AppRequest) => Promise<TModule>;

--- a/packages/micro-frontend/vitest.config.mts
+++ b/packages/micro-frontend/vitest.config.mts
@@ -1,13 +1,20 @@
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+
+const require = createRequire(import.meta.url);
+const nativeRequire = createRequire(require.resolve('@granite-js/native/@react-navigation/native'));
+const navigationRequire = createRequire(nativeRequire.resolve('@react-navigation/native'));
 
 export default defineConfig({
   resolve: {
     alias: {
+      '@granite-js/native/@react-navigation/native': navigationRequire.resolve('@react-navigation/core'),
       'react-native': fileURLToPath(new URL('./test/reactNative.ts', import.meta.url)),
     },
   },
   test: {
+    server: { deps: { inline: [/@react-navigation\//] } },
     // examples/portal/__tests__ is deliberately out of scope: those specs belong to the example's
     // own Jest setup (examples/portal/jest.config.js), which supplies the react-native preset this
     // config replaces with a stub. Run them with `yarn --cwd examples/portal test`, not here.

--- a/packages/react-native/src/app/Granite.navigation.spec.tsx
+++ b/packages/react-native/src/app/Granite.navigation.spec.tsx
@@ -1,0 +1,70 @@
+import { BaseNavigationContainer, createNavigationContainerRef } from '@granite-js/native/@react-navigation/native';
+import { render } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { InitialProps } from '../initial-props';
+import type { RequireContext, RouterProps } from '../router';
+import { Granite } from './Granite';
+
+vi.mock('./AppRoot', () => ({
+  AppRoot: ({ router }: { readonly router?: RouterProps }) => (
+    <BaseNavigationContainer ref={router?.ref ?? router?.navigationContainerRef}>{null}</BaseNavigationContainer>
+  ),
+}));
+vi.mock('./HostAppRoot', () => ({ HostAppRoot: () => null }));
+vi.mock('../constant-bridges', () => ({ getSchemeUri: () => 'granite://example/home' }));
+vi.mock('../polyfills', () => ({ setupPolyfills: () => undefined }));
+
+const context: RequireContext = Object.assign(
+  <T,>(id: string): T => {
+    throw new Error(`Unused route: ${id}`);
+  },
+  { id: 'navigation-runtime', keys: () => [], resolve: (id: string) => id }
+);
+const Container = ({ children }: PropsWithChildren<InitialProps>) => children;
+
+describe('registered app navigation ownership', () => {
+  it('overrides both registration-time refs with each mounted instance ref', () => {
+    // Given
+    const shared = createNavigationContainerRef<never>();
+    const alias = createNavigationContainerRef<never>();
+    const one = createNavigationContainerRef<never>();
+    const two = createNavigationContainerRef<never>();
+    const App = Granite.registerApp(Container, {
+      appName: 'navigation-runtime-scoped',
+      context,
+      router: { navigationContainerRef: shared, ref: alias },
+    });
+
+    // When
+    const first = render(<App platform="android" initialColorPreference="light" navigationContainerRef={one} />);
+    const second = render(<App platform="android" initialColorPreference="light" navigationContainerRef={two} />);
+    const firstContainer = one.current;
+    second.unmount();
+
+    // Then
+    expect(firstContainer).not.toBeNull();
+    expect(one.current).toBe(firstContainer);
+    expect(two.current).toBeNull();
+    expect(shared.current).toBeNull();
+    expect(alias.current).toBeNull();
+    first.unmount();
+  });
+
+  it('preserves explicit router refs when no instance ref is supplied', () => {
+    // Given
+    const navigation = createNavigationContainerRef<never>();
+    const App = Granite.registerApp(Container, {
+      appName: 'navigation-runtime-standalone',
+      context,
+      router: { navigationContainerRef: navigation },
+    });
+
+    // When
+    const rendered = render(<App platform="android" initialColorPreference="light" />);
+
+    // Then
+    expect(navigation.current).not.toBeNull();
+    rendered.unmount();
+  });
+});

--- a/packages/react-native/src/app/Granite.tsx
+++ b/packages/react-native/src/app/Granite.tsx
@@ -9,8 +9,10 @@ import { getSchemeUri } from '../constant-bridges';
 import { setupPolyfills } from '../polyfills';
 import { VisibilityChangedProvider } from '../visibility/useVisibilityChanged';
 
-interface GraniteAppRuntimeProps {
+export interface GraniteAppRuntimeProps {
   readonly presentationVisibility?: boolean;
+  /** A navigation ref owned by this mounted app instance, overriding registration-time router refs. */
+  readonly navigationContainerRef?: RouterProps['navigationContainerRef'];
 }
 
 type RegisteredAppProps = InitialProps & GraniteAppRuntimeProps;
@@ -79,16 +81,25 @@ const createApp = () => {
   }
 
   return {
-    registerApp( 
+    registerApp(
       AppContainer: ComponentType<PropsWithChildren<InitialProps>>,
-      { appName, context, router, initialScheme, setIosSwipeGestureEnabled, setiOSBackPressHandler, getInitialUrl }: GraniteProps
+      {
+        appName,
+        context,
+        router,
+        initialScheme,
+        setIosSwipeGestureEnabled,
+        setiOSBackPressHandler,
+        getInitialUrl,
+      }: GraniteProps
     ): (initialProps: RegisteredAppProps) => JSX.Element {
       if (appName === ENTRY_BUNDLE_NAME) {
         throw new Error(`Reserved app name 'shared' cannot be used`);
       }
 
-      function Root({ presentationVisibility = true, ...initialProps }: RegisteredAppProps) {
-        const initialSchemeValue = (typeof initialScheme === 'function' ? initialScheme() : initialScheme) ?? getSchemeUri();
+      function Root({ presentationVisibility = true, navigationContainerRef, ...initialProps }: RegisteredAppProps) {
+        const initialSchemeValue =
+          (typeof initialScheme === 'function' ? initialScheme() : initialScheme) ?? getSchemeUri();
 
         return (
           <VisibilityChangedProvider isVisible={presentationVisibility}>
@@ -101,7 +112,11 @@ const createApp = () => {
               getInitialUrl={getInitialUrl}
               appName={appName}
               context={context}
-              router={router}
+              router={
+                navigationContainerRef == null
+                  ? router
+                  : { ...router, navigationContainerRef, ref: navigationContainerRef }
+              }
             />
           </VisibilityChangedProvider>
         );

--- a/packages/react-native/src/app/index.ts
+++ b/packages/react-native/src/app/index.ts
@@ -1,4 +1,4 @@
 export { useInitialProps } from './context/InitialPropsContext';
 export { useInitialSearchParams } from './context/useInitialSearchParams';
 export { Granite } from './Granite';
-export type { GraniteProps } from './Granite';
+export type { GraniteProps, GraniteAppRuntimeProps } from './Granite';

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -34,4 +34,4 @@ export * from '@granite-js/blur-view';
 export { BackButton, useRouterBackHandler } from './router';
 
 export type { InitialProps, ColorPreference } from './initial-props';
-export type { GraniteProps } from './app';
+export type { GraniteProps, GraniteAppRuntimeProps } from './app';

--- a/packages/react-native/vitest.config.mts
+++ b/packages/react-native/vitest.config.mts
@@ -17,6 +17,7 @@ export default defineConfig({
     },
   ],
   test: {
+    server: { deps: { inline: [/@react-navigation\//] } },
     environment: 'jsdom',
     include: ['src/**/*.spec.{ts,tsx}'],
     testTimeout: 600_000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5642,6 +5642,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:7.28.5"
     "@babel/types": "npm:7.28.5"
+    "@granite-js/native": "workspace:*"
     "@granite-js/plugin-core": "workspace:*"
     "@granite-js/react-native": "workspace:*"
     "@granite-js/utils": "workspace:*"
@@ -5657,6 +5658,7 @@ __metadata:
     typescript: "catalog:tools"
     vitest: "npm:^4.0.12"
   peerDependencies:
+    "@granite-js/native": "*"
     "@granite-js/plugin-core": "*"
     "@granite-js/react-native": "*"
     react: "*"


### PR DESCRIPTION
Multiple mounted instances of the same app need independent navigation handles. This adds `runtime.sessions` with `subscribe`, `get`, and `getSnapshot`; each session exposes the existing React Navigation event interface and a lifecycle subscription.

Hosts connect `session.navigation` through the per-instance `navigationContainerRef` prop. Registered apps prioritize that ref over both registration-time router ref fields. Existing and future sessions can be observed outside React, and each observer's cleanup runs independently when a session finishes or the observer unsubscribes.

`onLifecycleEvent` is deprecated and remains supported through the new session subscription path, preserving lifecycle payloads and the wait for app disposal on the last session close. The README includes host wiring and migration examples.

Both packages use patch changesets (`2.3.2` to `2.3.3` in the current release plan). Existing `onLifecycleEvent` callbacks remain supported.

Validation:

- Micro-frontend: 177 tests passed.
- React Native: 96 tests passed, including type-level tests.
- Both package typechecks and the dependency-aware build passed; changed-file lint has no errors.
- A driver importing the built package entry mounted two real React Navigation containers and verified isolated events, actions, close cleanup, and observer unsubscription. Only the native event transport was simulated; no device binaries were exercised.
- Temporarily sharing one ref reproduced the isolation failure; restoring per-session refs passed.