### PR TITLE
fix(micro-frontend): mount iOS Portal content under an RCTRootComponentView anchor

### DIFF
--- a/.changeset/portal-host-react-root-anchor.md
+++ b/.changeset/portal-host-react-root-anchor.md
@@ -1,0 +1,5 @@
+---
+'@granite-js/micro-frontend': patch
+---
+
+Mount teleported iOS Portal content under an `RCTRootComponentView` anchor so react-native-screens treats hosted screens as root-mounted and stops attaching a second `RCTSurfaceTouchHandler` per screen. Hosted content now gets a single touch handler and container-relative page coordinates, like content under a regular React Native root.

--- a/packages/micro-frontend/README.md
+++ b/packages/micro-frontend/README.md
@@ -535,16 +535,33 @@ Import public APIs from `GraniteMicroFrontendRuntime`.
 
 ### Portal destination APIs
 
-| API                                         | Lifetime / behavior                                                                                               |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `-initWithFrame:`                           | Create and immediately activate a UIKit-owned Portal destination after React has booted.                          |
-| `-initWithFrame:deferredActivation:`        | Create before React boot without reading React feature flags.                                                     |
-| `-setName:`                                 | Register/unregister the destination name. Use `sessionId`.                                                        |
-| `-activateIfNeeded`                         | Create the Fabric host, attach its touch handler, and apply the pending name. Main thread only, after React boot. |
-| `isActivated`                               | Whether the underlying Fabric host exists.                                                                        |
-| `hasAttachedContent`                        | Whether teleported content is currently attached. This is readiness, not presentation visibility.                 |
-| `onContentDidAttach` / `onContentDidDetach` | Main-thread readiness callbacks for the first attach and last detach.                                             |
-| `-invalidate`                               | Unregister the host and clear callbacks during teardown.                                                          |
+| API                                         | Lifetime / behavior                                                                                                                                      |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-initWithFrame:`                           | Create and immediately activate a UIKit-owned Portal destination after React has booted.                                                                 |
+| `-initWithFrame:deferredActivation:`        | Create before React boot without reading React feature flags.                                                                                            |
+| `-setName:`                                 | Register/unregister the destination name. Use `sessionId`.                                                                                               |
+| `-activateIfNeeded`                         | Create the Fabric host under an `RCTRootComponentView` anchor, attach the touch handler, and apply the pending name. Main thread only, after React boot. |
+| `isActivated`                               | Whether the underlying Fabric host exists.                                                                                                               |
+| `hasAttachedContent`                        | Whether teleported content is currently attached. This is readiness, not presentation visibility.                                                        |
+| `onContentDidAttach` / `onContentDidDetach` | Main-thread readiness callbacks for the first attach and last detach.                                                                                    |
+| `-invalidate`                               | Unregister the host and clear callbacks during teardown.                                                                                                 |
+
+#### Touch handling under a Portal host
+
+`-activateIfNeeded` mounts the Fabric host under an `RCTRootComponentView`
+anchor:
+
+```text
+PortalHostContainerView       <- RCTSurfaceTouchHandler for all hosted content
+└── RCTRootComponentView      <- anchor, never registered with Fabric
+    └── PortalHostView        <- teleported content attaches here
+```
+
+react-native-screens attaches its own touch handler to any screen without an
+`RCTRootComponentView` above it. Without the anchor every hosted screen would add
+a second handler beneath the container's, and one tap would reach JS twice. The
+anchor keeps a single handler and page coordinates relative to the container,
+like content under a regular React Native root.
 
 ### UIViewController example
 

--- a/packages/micro-frontend/ios/PortalHostContainerView.h
+++ b/packages/micro-frontend/ios/PortalHostContainerView.h
@@ -28,9 +28,16 @@ NS_ASSUME_NONNULL_BEGIN
 /// when the host view is created. Pass nil to unregister.
 - (void)setName:(nullable NSString *)name;
 
-/// Creates the underlying Fabric host view, attaches the touch handler, and
-/// applies any pending name. No-op when already activated. Must be called on
-/// the main thread after the React runtime has booted.
+/// Creates the underlying Fabric host view under an `RCTRootComponentView`
+/// anchor, attaches the touch handler, and applies any pending name. No-op when
+/// already activated. Must be called on the main thread after the React runtime
+/// has booted.
+///
+/// The anchor makes hosted screens count as mounted under a React root for
+/// react-native-screens, so they do not attach a second touch handler beneath
+/// the container's. Hosted content therefore gets one handler and page
+/// coordinates relative to this container, like content under a regular React
+/// Native root.
 - (void)activateIfNeeded;
 
 /// Whether the underlying Fabric host view has been created.

--- a/packages/micro-frontend/ios/PortalHostContainerView.mm
+++ b/packages/micro-frontend/ios/PortalHostContainerView.mm
@@ -1,9 +1,11 @@
 #import "PortalHostContainerView.h"
 
+#import <React/RCTRootComponentView.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import "PortalHostView.h"
 
 @implementation PortalHostContainerView {
+  RCTRootComponentView *_reactRootAnchor;
   PortalHostView *_portalHostView;
   RCTSurfaceTouchHandler *_touchHandler;
   NSString *_pendingName;
@@ -49,14 +51,35 @@
     return;
   }
 
-  _portalHostView = [[PortalHostView alloc] initWithFrame:self.bounds];
+  // Hosted content mounts under an RCTRootComponentView anchor so react-native-screens treats
+  // hosted screens as root-mounted. RNSScreenView walks its superview chain for an
+  // RCTRootComponentView (or another RNSScreenView) in -isMountedUnderScreenOrReactRoot and, when
+  // it finds none, attaches its own RCTSurfaceTouchHandler in -didMoveToWindow. Under a Portal
+  // host that second handler would sit beneath this container's handler, every tap would reach JS
+  // twice, and on the second touchStart an ancestor PanResponder could steal the responder from
+  // the tapped Pressable. With the anchor, hosted screens see the same tree shape as content under
+  // a regular RCTSurfaceView: one handler, page coordinates relative to this container.
+  //
+  // The anchor is never registered with Fabric (tag 0, no event emitter, no shadow node); it is
+  // only a superview. The host view joins it through -addSubview:, not
+  // -mountChildComponentView:index:, so the anchor never posts RCTContentDidAppearNotification.
+  // It is created here rather than in -init for the same reason the host view is deferred: an
+  // RCTViewComponentView reads ReactNativeFeatureFlags while it settles into the view hierarchy,
+  // which must not happen before the host's boot-time override (see the header on deferred
+  // activation).
+  _reactRootAnchor = [[RCTRootComponentView alloc] initWithFrame:self.bounds];
+  _reactRootAnchor.autoresizingMask =
+      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  [self addSubview:_reactRootAnchor];
+
+  _portalHostView = [[PortalHostView alloc] initWithFrame:_reactRootAnchor.bounds];
   _portalHostView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   __weak PortalHostContainerView *weakSelf = self;
   _portalHostView.onSubviewCountChanged = ^{
     [weakSelf handleSubviewCountChanged];
   };
-  [self addSubview:_portalHostView];
+  [_reactRootAnchor addSubview:_portalHostView];
 
   _touchHandler = [RCTSurfaceTouchHandler new];
   [_touchHandler attachToView:self];

--- a/packages/micro-frontend/src/portal/PortalHostContainerView.ios.spec.ts
+++ b/packages/micro-frontend/src/portal/PortalHostContainerView.ios.spec.ts
@@ -1,0 +1,73 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { arch } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'vitest';
+
+const sourceDirectory = dirname(fileURLToPath(import.meta.url));
+const packageDirectory = resolve(sourceDirectory, '../..');
+const iosDirectory = resolve(packageDirectory, 'ios');
+const testDirectory = resolve(packageDirectory, 'test/ios');
+const harnessPath = resolve(testDirectory, 'PortalHostContainerReactRootAnchorHarness.mm');
+const portalHostContainerPath = resolve(iosDirectory, 'PortalHostContainerView.mm');
+const stubIncludeDirectory = resolve(testDirectory, 'stubs');
+const simulatorId = process.env.GRANITE_IOS_TOUCH_HARNESS_SIMULATOR;
+const runWithSimulator = process.platform === 'darwin' && simulatorId != null && simulatorId.length > 0;
+
+function compileReactRootAnchorHarness(temporaryDirectory: string): string {
+  const sdkPath = execFileSync('xcrun', ['--sdk', 'iphonesimulator', '--show-sdk-path'], {
+    encoding: 'utf8',
+  }).trim();
+  const binaryPath = join(temporaryDirectory, 'PortalHostContainerReactRootAnchorHarness');
+  const targetArch = arch === 'x64' ? 'x86_64' : 'arm64';
+
+  execFileSync('xcrun', [
+    '--sdk',
+    'iphonesimulator',
+    'clang++',
+    '-ObjC++',
+    '-fobjc-arc',
+    '-fblocks',
+    '-target',
+    `${targetArch}-apple-ios18.0-simulator`,
+    '-isysroot',
+    sdkPath,
+    '-framework',
+    'UIKit',
+    '-framework',
+    'Foundation',
+    '-framework',
+    'CoreGraphics',
+    '-I',
+    stubIncludeDirectory,
+    '-I',
+    iosDirectory,
+    portalHostContainerPath,
+    harnessPath,
+    '-o',
+    binaryPath,
+  ]);
+
+  return binaryPath;
+}
+
+function runReactRootAnchorHarness(simulator: string): void {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'granite-portal-anchor-'));
+  try {
+    const binaryPath = compileReactRootAnchorHarness(temporaryDirectory);
+    execFileSync('xcrun', ['simctl', 'spawn', simulator, binaryPath]);
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+describe('PortalHostContainerView React root anchor', () => {
+  it.runIf(runWithSimulator)('mounts hosted content under an RCTRootComponentView with one touch handler', () => {
+    if (simulatorId == null) {
+      throw new Error('GRANITE_IOS_TOUCH_HARNESS_SIMULATOR is required');
+    }
+    runReactRootAnchorHarness(simulatorId);
+  });
+});

--- a/packages/micro-frontend/test/ios/PortalHostContainerReactRootAnchorHarness.mm
+++ b/packages/micro-frontend/test/ios/PortalHostContainerReactRootAnchorHarness.mm
@@ -1,0 +1,170 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <React/RCTRootComponentView.h>
+#import <React/RCTSurfaceTouchHandler.h>
+
+#import "PortalHostContainerView.h"
+#import "PortalHostView.h"
+
+// The React classes PortalHostContainerView.mm depends on, reduced to what the harness needs. The
+// matching headers live under test/ios/stubs.
+@implementation RCTViewComponentView
+@end
+
+@implementation RCTRootComponentView
+@end
+
+@implementation RCTSurfaceTouchHandler
+- (instancetype)init
+{
+  if (self = [super initWithTarget:nil action:nil]) {
+    self.delegate = self;
+  }
+  return self;
+}
+
+- (void)attachToView:(UIView *)view
+{
+  [view addGestureRecognizer:self];
+}
+
+- (void)detachFromView:(UIView *)view
+{
+  [view removeGestureRecognizer:self];
+}
+@end
+
+// Minimal Fabric host: remembers the registered name and reports added subviews synchronously so
+// the container's readiness callback can be observed.
+static NSString *gRegisteredHostName;
+
+@implementation PortalHostView
+@synthesize onSubviewCountChanged;
+
+- (void)setName:(nullable NSString *)name
+{
+  gRegisteredHostName = [name copy];
+}
+
+- (NSInteger)nextInsertionIndexForChildAt:(NSInteger)childIndex
+{
+  return childIndex;
+}
+
+- (void)didAddSubview:(UIView *)subview
+{
+  [super didAddSubview:subview];
+  if (self.onSubviewCountChanged) {
+    self.onSubviewCountChanged();
+  }
+}
+@end
+
+static void Expect(BOOL condition, NSString *message)
+{
+  if (!condition) {
+    NSLog(@"%@", message);
+    exit(1);
+  }
+}
+
+// Mirrors RNSScreenView -isMountedUnderScreenOrReactRoot (react-native-screens 4.x, new
+// architecture): a screen counts as root-mounted when an RCTRootComponentView sits above it.
+static BOOL HasReactRootAncestor(UIView *view)
+{
+  for (UIView *parent = view.superview; parent != nil; parent = parent.superview) {
+    if ([parent isKindOfClass:[RCTRootComponentView class]]) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
+static NSUInteger SurfaceTouchHandlerCount(UIView *view)
+{
+  return [view.gestureRecognizers indexesOfObjectsPassingTest:^BOOL(
+                                      UIGestureRecognizer *recognizer, __unused NSUInteger index, __unused BOOL *stop) {
+    return [recognizer isKindOfClass:[RCTSurfaceTouchHandler class]];
+  }].count;
+}
+
+// container -> RCTRootComponentView anchor -> PortalHostView, one of each.
+static BOOL HasAnchoredHostTree(PortalHostContainerView *container)
+{
+  UIView *anchor = container.subviews.firstObject;
+  UIView *hostView = anchor.subviews.firstObject;
+  return container.subviews.count == 1 && [anchor isKindOfClass:[RCTRootComponentView class]] &&
+      anchor.subviews.count == 1 && [hostView isKindOfClass:[PortalHostView class]];
+}
+
+int main(void)
+{
+  @autoreleasepool {
+    // Deferred activation keeps the tree empty and the name unregistered until -activateIfNeeded.
+    PortalHostContainerView *container = [[PortalHostContainerView alloc] initWithFrame:CGRectMake(0, 0, 320, 480)
+                                                                         deferredActivation:YES];
+    [container setName:@"cart"];
+    Expect(!container.isActivated, @"deferred container should not be activated before -activateIfNeeded");
+    Expect(container.subviews.count == 0, @"deferred container should stay empty before activation");
+    Expect(
+        SurfaceTouchHandlerCount(container) == 0,
+        @"deferred container should not attach a touch handler before activation");
+    Expect(gRegisteredHostName == nil, @"deferred container should not register its name before activation");
+
+    // Activation mounts exactly one React root anchor with the Fabric host under it.
+    [container activateIfNeeded];
+    Expect(container.isActivated, @"container should be activated after -activateIfNeeded");
+    Expect(HasAnchoredHostTree(container), @"activation should mount one React root anchor with the host view under it");
+    Expect(
+        [gRegisteredHostName isEqualToString:@"cart"],
+        @"pending name should be applied to the host view on activation");
+    UIView *anchor = container.subviews.firstObject;
+    UIView *hostView = anchor.subviews.firstObject;
+
+    // Repeated activation is idempotent.
+    [container activateIfNeeded];
+    Expect(
+        HasAnchoredHostTree(container) && container.subviews.firstObject == anchor &&
+            anchor.subviews.firstObject == hostView,
+        @"repeated activation should keep the same anchor and host view");
+
+    // Exactly one surface touch handler, on the container; none on the anchor or the host.
+    Expect(SurfaceTouchHandlerCount(container) == 1, @"container should attach exactly one surface touch handler");
+    Expect(
+        SurfaceTouchHandlerCount(anchor) == 0 && SurfaceTouchHandlerCount(hostView) == 0,
+        @"anchor and host view should not attach touch handlers of their own");
+
+    // Anchor and host view follow the container bounds.
+    container.frame = CGRectMake(0, 0, 200, 300);
+    [container layoutIfNeeded];
+    Expect(
+        CGRectEqualToRect(anchor.frame, container.bounds) && CGRectEqualToRect(hostView.frame, anchor.bounds),
+        @"anchor and host view should follow the container bounds");
+
+    // Hosted content finds an RCTRootComponentView above it, which is what react-native-screens
+    // keys off, and the container still reports readiness when content attaches.
+    __block NSUInteger attachCount = 0;
+    container.onContentDidAttach = ^{
+      attachCount++;
+    };
+    UIView *hostedLeaf = [UIView new];
+    [hostView addSubview:hostedLeaf];
+    Expect(HasReactRootAncestor(hostedLeaf), @"hosted content should be mounted under a React root anchor");
+    Expect(
+        container.hasAttachedContent && attachCount == 1,
+        @"container should report the first attached content once");
+
+    // The same check fails for content outside the anchor; the anchor is what changes the answer.
+    UIView *plainParent = [UIView new];
+    UIView *plainLeaf = [UIView new];
+    [plainParent addSubview:plainLeaf];
+    Expect(!HasReactRootAncestor(plainLeaf), @"content outside a React root anchor should not count as root-mounted");
+
+    // Immediate activation produces the same tree shape.
+    PortalHostContainerView *immediate = [[PortalHostContainerView alloc] initWithFrame:CGRectMake(0, 0, 320, 480)];
+    Expect(
+        immediate.isActivated && HasAnchoredHostTree(immediate),
+        @"immediate activation should mount the same anchored host tree");
+  }
+  return 0;
+}

--- a/packages/micro-frontend/test/ios/stubs/React/RCTRootComponentView.h
+++ b/packages/micro-frontend/test/ios/stubs/React/RCTRootComponentView.h
@@ -1,0 +1,4 @@
+#import <React/RCTViewComponentView.h>
+
+@interface RCTRootComponentView : RCTViewComponentView
+@end

--- a/packages/micro-frontend/test/ios/stubs/React/RCTSurfaceTouchHandler.h
+++ b/packages/micro-frontend/test/ios/stubs/React/RCTSurfaceTouchHandler.h
@@ -1,0 +1,6 @@
+#import <UIKit/UIKit.h>
+
+@interface RCTSurfaceTouchHandler : UIGestureRecognizer <UIGestureRecognizerDelegate>
+- (void)attachToView:(UIView *)view;
+- (void)detachFromView:(UIView *)view;
+@end

--- a/packages/micro-frontend/test/ios/stubs/React/RCTViewComponentView.h
+++ b/packages/micro-frontend/test/ios/stubs/React/RCTViewComponentView.h
@@ -1,0 +1,4 @@
+#import <UIKit/UIKit.h>
+
+@interface RCTViewComponentView : UIView
+@end


### PR DESCRIPTION
## Problem

react-native-screens decides whether a screen is mounted under a React root by walking the superview chain for an `RCTRootComponentView` (or another `RNSScreenView`): `RNSScreen.mm -isMountedUnderScreenOrReactRoot`. Teleported Portal content is mounted under `PortalHostView`, a plain `RCTViewComponentView`, so the check fails and RNS attaches its own `RCTSurfaceTouchHandler` to every hosted screen in `-didMoveToWindow`.

Next to the container's handler, one tap reaches JS as two `touchStart`s. On the second one an ancestor PanResponder (a bottom sheet's drag handler, for example) steals the responder from the tapped Pressable, so `onPress` never fires. Toss hit this in the shopping option bottom sheet under the shared-runtime host (RNF-7672).

## Change

`PortalHostContainerView -activateIfNeeded` now mounts the Fabric host under an `RCTRootComponentView` anchor:

```text
PortalHostContainerView       <- RCTSurfaceTouchHandler for all hosted content
└── RCTRootComponentView      <- anchor, never registered with Fabric
    └── PortalHostView        <- teleported content attaches here
```

- The anchor is not registered with Fabric (tag 0, no event emitter, no shadow node). It only makes hosted screens root-mounted, exactly like content under a regular `RCTSurfaceView`: one touch handler, page coordinates relative to the container, no per-screen handler churn. The host view joins it through `-addSubview:`, not `-mountChildComponentView:index:`, so the anchor never posts `RCTContentDidAppearNotification`.
- It is created in `-activateIfNeeded`, not `-init`, for the same reason the host view is deferred: an `RCTViewComponentView` reads `ReactNativeFeatureFlags` on its way into the view hierarchy, which must not happen before the host's boot-time override.
- Nothing else in the dependency set keys off `RCTRootComponentView`: React core only registers the class with the component view factory, and react-native-screens takes the nearest one.

## Relation to #375

Branched from `v2`, not stacked on #375. #375 arbitrates which handler dispatches when several `RCTSurfaceTouchHandler`s share one touch path; this PR removes the cause of the react-native-screens case instead, so hosted screens never install a second handler in the first place. The cases #375 arbitrates — nested Portal hosts, and a host embedded under another React root — are not addressed here.

## Android

Not affected. On Android, touches reach JS only through the `JSTouchDispatcher` owned by a root view (`ReactRootView`, `ReactSurfaceView`, or a dialog's `DialogRootViewGroup`); ordinary views cannot attach a dispatcher of their own, so there is no per-screen handler to duplicate. `PortalReactRootView` extends `ReactRootView` and owns that single dispatcher, which means hosted content on Android is already under a real React root — the tree shape this PR recreates on iOS with the anchor.

react-native-screens on Android attaches no per-screen dispatcher (`Screen.onTouchEvent` only consumes form-sheet touches so the dimming view does not react), and its `BottomSheetDialogRootView` lives in a separate dialog window that `PortalReactRootView` never sees, so every window still has exactly one dispatcher. Both react-native-screens (`ScreenContainer` requires `parent is ReactRootView`) and react-native-gesture-handler (`RNGestureHandlerRootHelper` walks to the nearest `RootView`) resolve `PortalReactRootView` as their root, so the iOS-only gaps below do not apply there either.

Android's own Portal touch-target issue — native host view IDs being read as Fabric tags — is unrelated to this change and is addressed by the Android commit in #375.

## Not covered

react-native-screens' transition touch cancel (`-cancelTouchesInParent` → `rnscreens_findTouchHandlerInAncestorChain`) and react-native-gesture-handler's root recognizer both look for an `RCTSurfaceView` ancestor and stay no-ops under a Portal host. Those need changes in RNS / RNGH and are tracked separately.

## Test

- New `test/ios/PortalHostContainerReactRootAnchorHarness.mm`, driven by `src/portal/PortalHostContainerView.ios.spec.ts` against stub React headers on a simulator. It checks that deferred activation keeps the tree empty and the name unregistered until `-activateIfNeeded`; that activation mounts exactly one `RCTRootComponentView` with the `PortalHostView` under it and applies the pending name; that repeated activation is idempotent; that the container attaches exactly one `RCTSurfaceTouchHandler` while the anchor and host attach none; that anchor and host follow the container bounds; that hosted content has an `RCTRootComponentView` ancestor (the react-native-screens check) while content outside the anchor does not; that `onContentDidAttach` still fires once; and that immediate activation yields the same tree.
  Run: `GRANITE_IOS_TOUCH_HARNESS_SIMULATOR=<booted simulator udid> yarn test` in `packages/micro-frontend` (compiles the harness with the stub headers and runs it with `simctl spawn`). The spec is skipped when the variable is unset, so CI is unaffected.
- Toss iOS: the same anchor applied at the app level (toss-ios #57135) verified on a simulator under the shared-runtime host: bottom sheet items select and the sheet closes on tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
