### PR TITLE
feat(micro-frontend): expose runtime session snapshots

### DIFF
--- a/.changeset/runtime-session-snapshots.md
+++ b/.changeset/runtime-session-snapshots.md
@@ -1,0 +1,7 @@
+---
+'@granite-js/micro-frontend': minor
+---
+
+Add `getSessions()` and `onSessionsChanged()` for observing ordered session snapshots outside React. Snapshots include session identity, app name, scheme, and native presentation visibility, and update as native events arrive without waiting for React commits or app disposal.
+
+Keep session tracking active between consumer subscriptions and let `useMicroFrontendSessions()` read the same runtime-owned state, including sessions opened before it mounts. Existing lifecycle callbacks retain their commit and disposal timing.

--- a/packages/micro-frontend/README.md
+++ b/packages/micro-frontend/README.md
@@ -217,12 +217,48 @@ route best-effort native preload failures to its observability provider.
 
 The public runtime API is:
 
-| API                        | Responsibility                                                  |
-| -------------------------- | --------------------------------------------------------------- |
-| `preloadApp(appName)`      | Load and evaluate one app without importing an exposed module.  |
-| `importApp(request)`       | Ensure the app is evaluated and import `appName/exposedModule`. |
-| `evaluateScript(filePath)` | Evaluate a local file or Android packaged asset in the retained runtime. |
-| `onEvent(listener)`        | Subscribe to native open, close, and visibility events.         |
+| API                           | Responsibility                                                           |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| `preloadApp(appName)`         | Load and evaluate one app without importing an exposed module.           |
+| `importApp(request)`          | Ensure the app is evaluated and import `appName/exposedModule`.          |
+| `evaluateScript(filePath)`    | Evaluate a local file or Android packaged asset in the retained runtime. |
+| `onEvent(listener)`           | Subscribe to native open, close, and visibility events.                  |
+| `getSessions()`               | Read the current immutable session snapshot.                             |
+| `onSessionsChanged(listener)` | Subscribe to session snapshot changes.                                   |
+
+Session snapshots contain `sessionId`, `appName`, `scheme`, and `isVisible`.
+Sessions remain in opening order, including separate entries when the same app
+has multiple sessions. A newly opened session starts with `isVisible: false`;
+native visibility events update it, and `closeApp` removes it. Preloading an app
+does not create a session.
+
+```ts
+const subscription = runtime.onSessionsChanged((sessions) => {
+  updateSessionStatus(sessions);
+});
+updateSessionStatus(runtime.getSessions());
+
+// Stop observing when the integration is no longer needed.
+subscription.remove();
+```
+
+`getSessions()` only reads state. The first `onEvent` or `onSessionsChanged`
+subscription starts native event delivery after installing the runtime's
+listener. This can synchronously deliver queued events to the new subscriber.
+Subscriptions do not replay the current snapshot; subscribe first, then read
+`getSessions()` to initialize an observer without missing changes.
+
+The runtime retains one native subscription for its lifetime, even while all
+consumer subscriptions are removed. Later observers and React hosts can read
+the current sessions without reconstructing past events. Native session events
+update the snapshot before either kind of observer is notified, independently
+of React commits and app disposal. A failing observer is reported without
+preventing other observers from receiving the event.
+
+Snapshots and their session objects are frozen. A real change creates a new
+array while preserving unchanged session objects. Duplicate opens, unknown
+session IDs, and repeated visibility values retain the same snapshot and do not
+notify `onSessionsChanged` subscribers.
 
 The host can provide `onLifecycleEvent` when creating the runtime for logging
 and other observability integrations. Each event contains `session.id`,
@@ -291,9 +327,11 @@ function SessionRoot({ session }: { readonly session: MicroFrontendSessionState 
 }
 ```
 
-`useMicroFrontendSessions(runtime)` owns the fixed React subscription and folds
-native open, close, and visibility events into session descriptors. The host
-continues to own module selection and the rendered Portal tree.
+`useMicroFrontendSessions(runtime)` subscribes to the runtime's session snapshot
+with `useSyncExternalStore`. It reads the same state as non-React observers,
+including sessions opened before the hook mounted. It continues to report
+committed mount/unmount lifecycle events and run app disposal. The host owns
+module selection and the rendered Portal tree.
 
 The provider exposes the native session identity and combines
 `presentationVisibility` with Granite's existing `VisibilityChangedProvider`.

--- a/packages/micro-frontend/src/index.spec.types.ts
+++ b/packages/micro-frontend/src/index.spec.types.ts
@@ -1,5 +1,10 @@
 import { expectTypeOf } from 'vitest';
-import type { PendingHostComponent, registerPendingHostComponentRoute, usePendingHostComponentController } from './host';
+import type {
+  PendingHostComponent,
+  registerPendingHostComponentRoute,
+  usePendingHostComponentController,
+} from './host';
+import type { MicroFrontendRuntimeApi, MicroFrontendSessionState } from './index';
 
 interface PublicHostExports {
   readonly PendingHostComponent: typeof PendingHostComponent;
@@ -8,3 +13,7 @@ interface PublicHostExports {
 }
 
 expectTypeOf<typeof import('./index')>().toMatchTypeOf<PublicHostExports>();
+expectTypeOf<MicroFrontendRuntimeApi['getSessions']>().returns.toEqualTypeOf<readonly MicroFrontendSessionState[]>();
+expectTypeOf<MicroFrontendRuntimeApi['onSessionsChanged']>()
+  .parameter(0)
+  .toEqualTypeOf<(sessions: readonly MicroFrontendSessionState[]) => void>();

--- a/packages/micro-frontend/src/runtime/createMicroFrontendRuntime.ts
+++ b/packages/micro-frontend/src/runtime/createMicroFrontendRuntime.ts
@@ -5,12 +5,15 @@ import type {
   MicroFrontendRuntimeApi,
   MicroFrontendRuntimeEvent,
   MicroFrontendRuntimeEventSubscription,
+  MicroFrontendSessionEvent,
+  MicroFrontendSessionState,
 } from '../types';
 import { AppContainerNotFoundError, InvalidAppNameError } from './errors';
 import { getMicroFrontendGlobalContext } from './globalContext';
 import { setMicroFrontendLifecycleCallback } from './lifecycle';
 import { installNativeComponentRegistryCompatibility } from './nativeComponentRegistryCompatibility';
 import { parseAppRequest } from './parseAppRequest';
+import { createSessionStore } from './sessionStore';
 
 export interface NativeMicroFrontendRuntimeEvent {
   readonly name: string;
@@ -51,6 +54,37 @@ export function createMicroFrontendRuntimeWithDependencies(
 ): MicroFrontendRuntimeApi {
   // A fulfilled promise is the evaluated-state cache. Rejected evaluations remove themselves.
   const appEvaluations = new Map<string, Promise<void>>();
+  const sessionStore = createSessionStore();
+  const sessionListeners = new Set<(sessions: readonly MicroFrontendSessionState[]) => void>();
+  const eventListeners = new Set<(event: MicroFrontendSessionEvent) => void>();
+  let nativeSubscription: MicroFrontendRuntimeEventSubscription | undefined;
+
+  function startEventDelivery() {
+    if (nativeSubscription != null) {
+      return;
+    }
+    nativeSubscription = dependencies.nativeRuntime.onEvent((event) => {
+      const parsedEvent = dependencies.parseEvent(event);
+      switch (parsedEvent.name) {
+        case 'preloadApp':
+          void preloadApp(parsedEvent.params.appName).catch(dependencies.onPreloadError);
+          return;
+        case 'openApp':
+        case 'closeApp':
+        case 'sessionVisibilityChanged':
+          if (sessionStore.applyEvent(parsedEvent)) {
+            notifyListeners(sessionListeners, sessionStore.getSessions());
+          }
+          notifyListeners(eventListeners, parsedEvent);
+          return;
+        default: {
+          const exhaustiveEvent: never = parsedEvent;
+          return exhaustiveEvent;
+        }
+      }
+    });
+    dependencies.nativeRuntime.startEventDelivery();
+  }
 
   function resetFailedEvaluation(appName: string) {
     appEvaluations.delete(appName);
@@ -101,30 +135,32 @@ export function createMicroFrontendRuntimeWithDependencies(
       await preloadApp(appName);
       return dependencies.registry.importModule<TModule>(request);
     },
+    getSessions: sessionStore.getSessions,
+    onSessionsChanged(listener) {
+      const callback = (sessions: readonly MicroFrontendSessionState[]) => listener(sessions);
+      sessionListeners.add(callback);
+      startEventDelivery();
+      return { remove: () => sessionListeners.delete(callback) };
+    },
     onEvent(listener) {
-      const subscription = dependencies.nativeRuntime.onEvent((event) => {
-        const parsedEvent = dependencies.parseEvent(event);
-        switch (parsedEvent.name) {
-          case 'preloadApp':
-            void preloadApp(parsedEvent.params.appName).catch(dependencies.onPreloadError);
-            return;
-          case 'openApp':
-          case 'closeApp':
-          case 'sessionVisibilityChanged':
-            listener(parsedEvent);
-            return;
-          default: {
-            const exhaustiveEvent: never = parsedEvent;
-            return exhaustiveEvent;
-          }
-        }
-      });
-      dependencies.nativeRuntime.startEventDelivery();
-      return subscription;
+      const callback = (event: MicroFrontendSessionEvent) => listener(event);
+      eventListeners.add(callback);
+      startEventDelivery();
+      return { remove: () => eventListeners.delete(callback) };
     },
   };
 
   setMicroFrontendLifecycleCallback(runtime, dependencies.onLifecycleEvent);
 
   return runtime;
+}
+
+function notifyListeners<TEvent>(listeners: ReadonlySet<(event: TEvent) => void>, event: TEvent): void {
+  listeners.forEach((listener) => {
+    try {
+      listener(event);
+    } catch (error) {
+      console.error('Failed to run a micro-frontend runtime listener', error);
+    }
+  });
 }

--- a/packages/micro-frontend/src/runtime/sessionSnapshots.spec.ts
+++ b/packages/micro-frontend/src/runtime/sessionSnapshots.spec.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSessionRuntimeFixture } from '../../test/sessionRuntimeFixture';
+import type { MicroFrontendSessionState } from '../types';
+
+const firstOpen = {
+  name: 'openApp',
+  params: { appName: 'catalog', sessionId: 'catalog:1', scheme: 'granite://catalog/first' },
+} as const;
+const secondOpen = {
+  name: 'openApp',
+  params: { appName: 'catalog', sessionId: 'catalog:2', scheme: 'granite://catalog/second' },
+} as const;
+
+describe('runtime session snapshots', () => {
+  it('reads without starting native delivery and receives queued events on first subscription', () => {
+    // Given
+    const { runtime, emit, nativeRuntime, listenerCount } = createSessionRuntimeFixture();
+    emit(firstOpen);
+    emit({ name: 'sessionVisibilityChanged', params: { sessionId: 'catalog:1', isVisible: true } });
+    expect(runtime.getSessions()).toEqual([]);
+    expect(nativeRuntime.startEventDelivery).not.toHaveBeenCalled();
+    expect(listenerCount).toBe(0);
+    const changes = vi.fn();
+
+    // When
+    runtime.onSessionsChanged(changes);
+
+    // Then
+    expect(changes).toHaveBeenCalledTimes(2);
+    expect(runtime.getSessions()).toEqual([{ ...firstOpen.params, isVisible: true }]);
+    expect(changes).toHaveBeenLastCalledWith(runtime.getSessions());
+  });
+
+  it('updates the snapshot before either kind of observer reads it', () => {
+    // Given
+    const { runtime, emit } = createSessionRuntimeFixture();
+    const observed: (readonly MicroFrontendSessionState[])[] = [];
+    runtime.onEvent(() => observed.push(runtime.getSessions()));
+    runtime.onSessionsChanged((sessions) => observed.push(sessions));
+
+    // When
+    emit(firstOpen);
+
+    // Then
+    expect(observed).toHaveLength(2);
+    expect(observed[0]).toBe(runtime.getSessions());
+    expect(observed[1]).toBe(runtime.getSessions());
+    expect(runtime.getSessions()).toEqual([{ ...firstOpen.params, isVisible: false }]);
+  });
+
+  it('preserves opening order and distinguishes multiple sessions of the same app', () => {
+    // Given
+    const { runtime, emit } = createSessionRuntimeFixture();
+    runtime.onSessionsChanged(() => undefined);
+    emit(firstOpen);
+    emit(secondOpen);
+    const beforeVisibility = runtime.getSessions();
+
+    // When
+    emit({ name: 'sessionVisibilityChanged', params: { sessionId: 'catalog:1', isVisible: true } });
+    emit({ name: 'sessionVisibilityChanged', params: { sessionId: 'catalog:2', isVisible: true } });
+
+    // Then
+    expect(runtime.getSessions()).toEqual([
+      { ...firstOpen.params, isVisible: true },
+      { ...secondOpen.params, isVisible: true },
+    ]);
+    expect(
+      runtime
+        .getSessions()
+        .filter((session) => session.isVisible)
+        .at(-1)?.scheme
+    ).toBe(secondOpen.params.scheme);
+    expect(beforeVisibility).toEqual([
+      { ...firstOpen.params, isVisible: false },
+      { ...secondOpen.params, isVisible: false },
+    ]);
+  });
+
+  it('preserves snapshot identity and suppresses notifications for unchanged state', () => {
+    // Given
+    const { runtime, emit } = createSessionRuntimeFixture();
+    const changes = vi.fn();
+    runtime.onSessionsChanged(changes);
+    emit(firstOpen);
+    const snapshot = runtime.getSessions();
+    changes.mockClear();
+
+    // When
+    emit(firstOpen);
+    emit({ name: 'closeApp', params: { sessionId: 'unknown' } });
+    emit({ name: 'sessionVisibilityChanged', params: { sessionId: 'unknown', isVisible: true } });
+    emit({ name: 'sessionVisibilityChanged', params: { sessionId: 'catalog:1', isVisible: false } });
+
+    // Then
+    expect(runtime.getSessions()).toBe(snapshot);
+    expect(changes).not.toHaveBeenCalled();
+  });
+
+  it('keeps tracking between subscriptions and lets late observers read the current snapshot', () => {
+    // Given
+    const fixture = createSessionRuntimeFixture();
+    const first = vi.fn();
+    const subscription = fixture.runtime.onSessionsChanged(first);
+    fixture.emit(firstOpen);
+    subscription.remove();
+
+    // When
+    fixture.emit(secondOpen);
+    fixture.emit({ name: 'closeApp', params: { sessionId: 'catalog:1' } });
+    const late = vi.fn();
+    fixture.runtime.onSessionsChanged(late);
+
+    // Then
+    expect(fixture.runtime.getSessions()).toEqual([{ ...secondOpen.params, isVisible: false }]);
+    expect(first).toHaveBeenCalledOnce();
+    expect(late).not.toHaveBeenCalled();
+    expect(fixture.listenerCount).toBe(1);
+    expect(fixture.nativeRuntime.startEventDelivery).toHaveBeenCalledOnce();
+  });
+
+  it('isolates an observer failure so session and event observers still receive the change', () => {
+    // Given
+    const { runtime, emit } = createSessionRuntimeFixture();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const changes = vi.fn();
+    const events = vi.fn();
+    runtime.onSessionsChanged(() => {
+      throw new Error('observer failed');
+    });
+    runtime.onSessionsChanged(changes);
+    runtime.onEvent(events);
+
+    // When
+    emit(firstOpen);
+
+    // Then
+    expect(changes).toHaveBeenCalledWith(runtime.getSessions());
+    expect(events).toHaveBeenCalledWith(firstOpen);
+    expect(consoleError).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+
+  it('handles native preloads once without adding a session or notifying session observers', async () => {
+    // Given
+    const { runtime, emit, adapter } = createSessionRuntimeFixture();
+    const changes = vi.fn();
+    runtime.onSessionsChanged(changes);
+    runtime.onEvent(() => undefined);
+    const empty = runtime.getSessions();
+
+    // When
+    emit({ name: 'preloadApp', params: { appName: 'catalog' } });
+    await runtime.preloadApp('catalog');
+
+    // Then
+    expect(adapter.loadBundle).toHaveBeenCalledOnce();
+    expect(changes).not.toHaveBeenCalled();
+    expect(runtime.getSessions()).toBe(empty);
+  });
+
+  it('removes duplicate registrations independently', () => {
+    // Given
+    const { runtime, emit } = createSessionRuntimeFixture();
+    const changes = vi.fn();
+    const events = vi.fn();
+    const firstChanges = runtime.onSessionsChanged(changes);
+    runtime.onSessionsChanged(changes);
+    const firstEvents = runtime.onEvent(events);
+    runtime.onEvent(events);
+    emit(firstOpen);
+
+    // When
+    firstChanges.remove();
+    firstEvents.remove();
+    emit(secondOpen);
+
+    // Then
+    expect(changes).toHaveBeenCalledTimes(3);
+    expect(events).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/micro-frontend/src/runtime/sessionStore.ts
+++ b/packages/micro-frontend/src/runtime/sessionStore.ts
@@ -1,0 +1,40 @@
+import type { MicroFrontendSessionEvent, MicroFrontendSessionState } from '../types';
+
+export function createSessionStore() {
+  let sessions: readonly MicroFrontendSessionState[] = Object.freeze([]);
+
+  return {
+    getSessions: () => sessions,
+    applyEvent(event: MicroFrontendSessionEvent): boolean {
+      const nextSessions = reduceSessions(sessions, event);
+      if (nextSessions === sessions) {
+        return false;
+      }
+      sessions = Object.freeze(nextSessions);
+      return true;
+    },
+  };
+}
+
+function reduceSessions(
+  sessions: readonly MicroFrontendSessionState[],
+  event: MicroFrontendSessionEvent
+): readonly MicroFrontendSessionState[] {
+  const session = sessions.find(({ sessionId }) => sessionId === event.params.sessionId);
+  switch (event.name) {
+    case 'openApp':
+      return session == null ? [...sessions, Object.freeze({ ...event.params, isVisible: false })] : sessions;
+    case 'closeApp':
+      return session == null ? sessions : sessions.filter(({ sessionId }) => sessionId !== event.params.sessionId);
+    case 'sessionVisibilityChanged':
+      return session == null || session.isVisible === event.params.isVisible
+        ? sessions
+        : sessions.map((current) =>
+            current === session ? Object.freeze({ ...current, isVisible: event.params.isVisible }) : current
+          );
+    default: {
+      const exhaustiveEvent: never = event;
+      return exhaustiveEvent;
+    }
+  }
+}

--- a/packages/micro-frontend/src/session/useMicroFrontendSessions.lifecycle.spec.tsx
+++ b/packages/micro-frontend/src/session/useMicroFrontendSessions.lifecycle.spec.tsx
@@ -64,7 +64,7 @@ function createRuntimeFixture() {
   };
 }
 
-function renderSessions(runtime: Pick<MicroFrontendRuntimeApi, 'onEvent'>) {
+function renderSessions(runtime: MicroFrontendRuntimeApi) {
   let current: readonly MicroFrontendSessionState[] = [];
   function Consumer() {
     current = useMicroFrontendSessions(runtime);
@@ -154,6 +154,7 @@ describe('useMicroFrontendSessions app lifetime', () => {
       },
       activeSessions: [{ appName: 'app-1', id: 'app-1:1' }],
     });
+    expect(fixture.runtime.getSessions()).toEqual([]);
 
     await act(async () => finishDispose?.());
     expect(fixture.onLifecycleEvent).toHaveBeenCalledTimes(4);
@@ -253,9 +254,10 @@ describe('useMicroFrontendSessions app lifetime', () => {
     listenerCounts.push(fixture.listenerCount);
     const remounted = renderSessions(fixture.runtime);
     listenerCounts.push(fixture.listenerCount);
-    expect(remounted.current).toEqual([]);
+    expect(remounted.current).toBe(fixture.runtime.getSessions());
+    expect(remounted.current.map(({ sessionId }) => sessionId)).toEqual(['app-2:1']);
     remounted.unmount();
     listenerCounts.push(fixture.listenerCount);
-    expect(listenerCounts).toEqual([1, 0, 1, 0]);
+    expect(listenerCounts).toEqual([1, 1, 1, 1]);
   });
 });

--- a/packages/micro-frontend/src/session/useMicroFrontendSessions.spec.tsx
+++ b/packages/micro-frontend/src/session/useMicroFrontendSessions.spec.tsx
@@ -1,36 +1,13 @@
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type MicroFrontendSessionState, useMicroFrontendSessions } from './useMicroFrontendSessions';
+import { createSessionRuntimeFixture as createRuntimeFixture } from '../../test/sessionRuntimeFixture';
 import { getIsPendingHostComponentHidden, hidePendingHostComponent } from '../host/pendingHostComponentStore';
-import type { MicroFrontendRuntimeApi, MicroFrontendSessionEvent } from '../types';
+import type { MicroFrontendRuntimeApi } from '../types';
 
 Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', true);
 
-function createRuntimeFixture() {
-  const listeners = new Set<(event: MicroFrontendSessionEvent) => void>();
-  const remove = vi.fn<(listener: (event: MicroFrontendSessionEvent) => void) => void>((listener) => {
-    listeners.delete(listener);
-  });
-  const runtime: Pick<MicroFrontendRuntimeApi, 'onEvent'> = {
-    onEvent(nextListener) {
-      listeners.add(nextListener);
-      return { remove: () => remove(nextListener) };
-    },
-  };
-
-  return {
-    emit(event: MicroFrontendSessionEvent) {
-      listeners.forEach((listener) => listener(event));
-    },
-    get listenerCount() {
-      return listeners.size;
-    },
-    remove,
-    runtime,
-  };
-}
-
-function renderSessions(runtime: Pick<MicroFrontendRuntimeApi, 'onEvent'>) {
+function renderSessions(runtime: MicroFrontendRuntimeApi) {
   let current: readonly MicroFrontendSessionState[] = [];
 
   function Consumer() {
@@ -197,16 +174,46 @@ describe('useMicroFrontendSessions', () => {
     rendered.unmount();
   });
 
-  it('removes the runtime subscription when the host unmounts', () => {
+  it('removes the snapshot observer when the host unmounts while retaining native tracking', () => {
     // Given
     const fixture = createRuntimeFixture();
+    const subscribe = fixture.runtime.onSessionsChanged;
+    const remove = vi.fn();
+    vi.spyOn(fixture.runtime, 'onSessionsChanged').mockImplementation((listener) => {
+      const subscription = subscribe(listener);
+      return {
+        remove() {
+          remove();
+          subscription.remove();
+        },
+      };
+    });
     const rendered = renderSessions(fixture.runtime);
 
     // When
     rendered.unmount();
 
     // Then
-    expect(fixture.remove).toHaveBeenCalledOnce();
-    expect(fixture.listenerCount).toBe(0);
+    expect(remove).toHaveBeenCalledOnce();
+    expect(fixture.listenerCount).toBe(1);
+  });
+
+  it('renders the current snapshot when native sessions opened before the host mounted', () => {
+    // Given
+    const fixture = createRuntimeFixture();
+    fixture.runtime.onEvent(() => undefined).remove();
+    fixture.emit({
+      name: 'openApp',
+      params: { appName: 'catalog', sessionId: 'catalog:1', scheme: 'granite://catalog/products' },
+    });
+    fixture.emit({ name: 'sessionVisibilityChanged', params: { sessionId: 'catalog:1', isVisible: true } });
+
+    // When
+    const rendered = renderSessions(fixture.runtime);
+
+    // Then
+    expect(rendered.current).toBe(fixture.runtime.getSessions());
+    expect(rendered.current[0]?.isVisible).toBe(true);
+    rendered.unmount();
   });
 });

--- a/packages/micro-frontend/src/session/useMicroFrontendSessions.ts
+++ b/packages/micro-frontend/src/session/useMicroFrontendSessions.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useReducer, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useSyncExternalStore } from 'react';
 import { installPendingHostComponentBridge, resetPendingHostComponent } from '../host/pendingHostComponentStore';
 import { emitMicroFrontendLifecycleEvent } from '../runtime/lifecycle';
 import { disposeAppResources } from '../runtime/registry';
@@ -6,53 +6,19 @@ import type {
   MicroFrontendLifecycleEvent,
   MicroFrontendLifecycleSession,
   MicroFrontendRuntimeApi,
-  MicroFrontendSessionEvent,
+  MicroFrontendSessionState,
 } from '../types';
 
-export interface MicroFrontendSessionState {
-  readonly appName: string;
-  readonly sessionId: string;
-  readonly scheme: string;
-  readonly isVisible: boolean;
-}
+export type { MicroFrontendSessionState } from '../types';
 
 const INITIAL_SESSIONS: readonly MicroFrontendSessionState[] = [];
 
-function reduceMicroFrontendSessions(
-  sessions: readonly MicroFrontendSessionState[],
-  event: MicroFrontendSessionEvent
-): readonly MicroFrontendSessionState[] {
-  switch (event.name) {
-    case 'openApp':
-      return sessions.some(({ sessionId }) => sessionId === event.params.sessionId)
-        ? sessions
-        : [
-            ...sessions,
-            {
-              appName: event.params.appName,
-              sessionId: event.params.sessionId,
-              scheme: event.params.scheme,
-              isVisible: false,
-            },
-          ];
-    case 'closeApp':
-      return sessions.filter(({ sessionId }) => sessionId !== event.params.sessionId);
-    case 'sessionVisibilityChanged':
-      return sessions.map((session) =>
-        session.sessionId === event.params.sessionId ? { ...session, isVisible: event.params.isVisible } : session
-      );
-    default: {
-      const exhaustiveEvent: never = event;
-      return exhaustiveEvent;
-    }
-  }
-}
-
 export function useMicroFrontendSessions(
-  runtime: Pick<MicroFrontendRuntimeApi, 'onEvent'>
+  runtime: Pick<MicroFrontendRuntimeApi, 'onEvent' | 'getSessions' | 'onSessionsChanged'>
 ): readonly MicroFrontendSessionState[] {
-  const [sessions, dispatch] = useReducer(reduceMicroFrontendSessions, INITIAL_SESSIONS);
-  const previousSessionsRef = useRef(sessions);
+  const subscribe = useCallback((listener: () => void) => runtime.onSessionsChanged(listener).remove, [runtime]);
+  const sessions = useSyncExternalStore(subscribe, runtime.getSessions);
+  const previousSessionsRef = useRef(INITIAL_SESSIONS);
 
   useEffect(() => {
     const previousSessions = previousSessionsRef.current;
@@ -106,7 +72,6 @@ export function useMicroFrontendSessions(
       if (event.name === 'openApp') {
         resetPendingHostComponent();
       }
-      dispatch(event);
     });
 
     return () => subscription.remove();

--- a/packages/micro-frontend/src/types.ts
+++ b/packages/micro-frontend/src/types.ts
@@ -48,6 +48,13 @@ export interface MicroFrontendRuntimeEventSubscription {
   readonly remove: () => void;
 }
 
+export interface MicroFrontendSessionState {
+  readonly appName: string;
+  readonly sessionId: string;
+  readonly scheme: string;
+  readonly isVisible: boolean;
+}
+
 export interface MicroFrontendLifecycleSession {
   readonly appName: string;
   readonly id: string;
@@ -66,5 +73,11 @@ export interface MicroFrontendRuntimeApi {
   readonly evaluateScript: (filePath: string) => Promise<void>;
   readonly preloadApp: (appName: string) => Promise<void>;
   readonly importApp: <TModule>(request: AppRequest) => Promise<TModule>;
+  /** Read the current snapshot without starting event delivery. */
+  readonly getSessions: () => readonly MicroFrontendSessionState[];
+  /** Subscribe to changes and start native delivery if needed; read getSessions() for the initial snapshot. */
+  readonly onSessionsChanged: (
+    listener: (sessions: readonly MicroFrontendSessionState[]) => void
+  ) => MicroFrontendRuntimeEventSubscription;
   readonly onEvent: (listener: (event: MicroFrontendSessionEvent) => void) => MicroFrontendRuntimeEventSubscription;
 }

--- a/packages/micro-frontend/test/sessionRuntimeFixture.ts
+++ b/packages/micro-frontend/test/sessionRuntimeFixture.ts
@@ -1,0 +1,54 @@
+import { vi } from 'vitest';
+import {
+  createMicroFrontendRuntimeWithDependencies,
+  type NativeMicroFrontendRuntime,
+  type NativeMicroFrontendRuntimeEvent,
+} from '../src/runtime/createMicroFrontendRuntime';
+import { parseNativeRuntimeEvent } from '../src/runtime/parseNativeRuntimeEvent';
+
+export function createSessionRuntimeFixture() {
+  const listeners = new Set<(event: NativeMicroFrontendRuntimeEvent) => void>();
+  const queuedEvents: NativeMicroFrontendRuntimeEvent[] = [];
+  let isDelivering = false;
+  const nativeRuntime: NativeMicroFrontendRuntime = {
+    evaluateScript: vi.fn(async () => undefined),
+    onEvent(listener) {
+      listeners.add(listener);
+      return { remove: () => listeners.delete(listener) };
+    },
+    startEventDelivery: vi.fn(() => {
+      isDelivering = true;
+      queuedEvents.splice(0).forEach((event) => listeners.forEach((listener) => listener(event)));
+    }),
+  };
+  const adapter = { loadBundle: vi.fn(async () => ({ filePath: '/bundles/example.hbc' })) };
+  const runtime = createMicroFrontendRuntimeWithDependencies({
+    adapter,
+    nativeRuntime,
+    onPreloadError: vi.fn(),
+    registry: {
+      hasContainer: () => true,
+      removeContainer: vi.fn(),
+      importModule: () => {
+        throw new Error('No exposed module in this fixture');
+      },
+    },
+    removePendingHostComponentRoutes: vi.fn(),
+    parseEvent: parseNativeRuntimeEvent,
+  });
+  return {
+    runtime,
+    adapter,
+    nativeRuntime,
+    emit(event: NativeMicroFrontendRuntimeEvent) {
+      if (isDelivering) {
+        listeners.forEach((listener) => listener(event));
+      } else {
+        queuedEvents.push(event);
+      }
+    },
+    get listenerCount() {
+      return listeners.size;
+    },
+  };
+}


### PR DESCRIPTION
Session state was owned by the React hook, so non-React integrations had to maintain their own copy and newly mounted hosts could miss earlier native events.

Add `getSessions()` and `onSessionsChanged()` with ordered, immutable snapshots containing `sessionId`, `appName`, `scheme`, and `isVisible`. The runtime updates this state before notifying observers, retains native tracking between consumer subscriptions, and shares the same snapshot with `useMicroFrontendSessions()`. Existing lifecycle callbacks keep their React commit and disposal timing.

The getter is read-only. The first event or snapshot subscription starts native delivery; subscribers can then read the current snapshot. Unchanged state preserves array identity and does not trigger snapshot callbacks.

Validation: package build with dependencies, typecheck, ESLint, formatting, and 174 passing tests (2 existing iOS-only tests skipped by the default configuration). A standalone driver against the built JavaScript verified queued delivery, immutable snapshots, observer gaps, visible-session selection, invalid input, and close behavior.
